### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rails:4.2.5
+MAINTAINER Colin Fleming <c3flemin@gmail.com> 
+
+# install packages
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install
+
+COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,16 @@ FROM rails:4.2.5
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # install packages
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev 
+
+# for nokogiri
+RUN apt-get install -y libxml2-dev libxslt1-dev
+
+# for capybara-webkit
+RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
+
+# for a JS runtime
+RUN apt-get install -y nodejs
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Current wireframe assets are available here:
 * [DCAFwireframe110915.ai](https://drive.google.com/open?id=0B2HlOoxw2oq1a0hDYmt0ZE55VGs)  
 * [DCAFwireframe110915.pdf](https://drive.google.com/open?id=0B2HlOoxw2oq1UmhxVVJ1SlJOLTA)
 
+## Dockerizing
+
+To manage the dependencies and save us all some headache, we've Dockered this app. If you have `boot2docker` and `docker` installed, you can run the following: 
+* `$ boot2docker up`
+* `$ docker-compose build && docker-compose up`
+* Navigate your browser to `http://localhost:3000`
+
 ## Setting up MongoDB
 
 * Install MongoDB locally if you haven't (`$ brew install mongodb`, for example)

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Current wireframe assets are available here:
 
 ## Dockerizing
 
-To manage the dependencies and save us all some headache, we've Dockered this app. If you have `boot2docker` and `docker` installed, you can run the following: 
-* `$ boot2docker up`
+To manage the dependencies and save us all some headache, we've Dockered this app. If you're docker-savvy, you can run the following to fire up mongo and the rails server: 
 * `$ docker-compose build && docker-compose up`
-* Navigate your browser to `http://localhost:3000`
 
 ## Setting up MongoDB
 

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - <%= ENV['mongohost'] || 'localhost' %>:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+web:
+  build: .
+  command: bundle exec rails s -p 3000 -b '0.0.0.0'
+  volumes:
+    - .:/usr/src/app
+  ports:
+    - "3000:3000"
+  links:
+    - db
+  environment:
+    YR_VAR_HERE: thing
+db:
+  image: mongo
+  volumes:
+    - data/mongodb:/data/db
+  ports:
+    - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,8 @@ web:
   links:
     - db
   environment:
-    mongohost: thing
+    mongohost: dcafcasemanagement_db_1
 db:
   image: mongo
-  volumes:
-    - data/mongodb:/data/db
   ports:
     - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 web:
   build: .
-  command: bundle exec rails s -p 3000 -b '0.0.0.0'
+  command: rails s -p 3000 -b 0.0.0.0
   volumes:
     - .:/usr/src/app
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ web:
   links:
     - db
   environment:
-    YR_VAR_HERE: thing
+    mongohost: thing
 db:
   image: mongo
   volumes:


### PR DESCRIPTION
Adds `Dockerfile` and `docker-compose.yml`, so we can containerize the dependencies and offer a somewhat simpler option. 

That said, I am nobody's idea of a devops person, so this is a pretty approximate stab. `$ docker-compose build && docker-compose up` seems to fire up both containers without issue, allows me to visit the rails app, create and retrieve a User record, etc. (Though I also tried to pop into `rails c` and couldn't, so idk what the issue is there.)

Anyone on the team have some more experience with devops matters than I do and want to review? @Kevin-Wei maybe? It's not urgent so we can let it hang for awhile without issue. 