### PR TITLE
Add testing and continuous integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,6 @@ group :development, :test do
   gem 'spring'
 end
 
+group :test do 
+  gem 'factory_girl_rails'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,10 @@ group :development, :test do
 end
 
 group :test do 
+  gem 'minitest-reporters'
+  gem 'mini_backtrace'
+  gem 'minitest-spec-rails'
   gem 'factory_girl_rails'
+  gem 'faker'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arel (6.0.3)
     autoprefixer-rails (6.2.1)
       execjs
@@ -73,6 +74,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.5.0)
+      i18n (~> 0.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -89,8 +92,19 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.99)
+    mini_backtrace (0.1.3)
+      minitest (> 1.2.0)
+      rails (>= 2.3.3)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
+    minitest-reporters (1.1.2)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    minitest-spec-rails (5.2.2)
+      minitest (~> 5.0)
+      rails (~> 4.1)
     mongo (2.2.1)
       bson (~> 4.0)
     mongoid (5.0.1)
@@ -137,6 +151,7 @@ GEM
       json (~> 1.4)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
+    ruby-progressbar (1.7.5)
     sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -183,8 +198,12 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   devise (~> 3.5, >= 3.5.2)
   factory_girl_rails
+  faker
   jbuilder (~> 2.0)
   jquery-rails
+  mini_backtrace
+  minitest-reporters
+  minitest-spec-rails
   mongoid (~> 5.0.0)
   pundit (~> 1.0, >= 1.0.1)
   rails (= 4.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,11 @@ GEM
       warden (~> 1.2.3)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -177,6 +182,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise (~> 3.5, >= 3.5.2)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   mongoid (~> 5.0.0)

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: 2.2.0p0
+    version: 2.2.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.2.0p0

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class CasesControllerTest < ActionController::TestCase
-  test "should get index" do
+  it "should get index" do
     get :index
     assert_response :success
   end
-
 end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :user do
+    name "Billy Everyteen"
+    email "billy@everyteen.com"
+    confirmed_at { 2.months.ago }
+  end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -2,6 +2,5 @@ FactoryGirl.define do
   factory :user do
     name "Billy Everyteen"
     email "billy@everyteen.com"
-    confirmed_at { 2.months.ago }
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined.  If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-#  column: value
+# Mongoid and fixtures don't get along. Use factories instead.

--- a/test/integration/everything_ok_alarm_test.rb
+++ b/test/integration/everything_ok_alarm_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class EverythingOkAlarmTest < ActionDispatch::IntegrationTest
+  # confirm that the app is loading and that the main page is clean
+  it "SHOULD SOUND THIS ALARM WHEN EVERYTHING IS OKAY" do 
+    get '/'
+    assert_response :success
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,10 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/reporters'
+Minitest::Reporters.use!
 
 class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+  include FactoryGirl::Syntax::Methods
 
-  # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
Sets up Minitest and circleCI continuous integration, so we can add tests painlessly going forward, and protect ourselves from introducing breaking changes. 

Full breakout of what this adds: 
* Minitest related reporting gems
* circle.yml file, to set a ruby version in test without forcing one in the gemfile
* Add and set up Factory Girl for fixtures
* Creates an integration test to make sure the main page loads 