### PR TITLE
roll firstname lastname back to just name for User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,7 @@ class User
          :recoverable, :rememberable, :trackable, :validatable
 
   # Non-devise generated
-  field :first_name, type: String
-  field :last_name, type: String
+  field :name, type: String
   field :line, type: String
   field :role, type: String
 


### PR DESCRIPTION
This limits mongo's name fields to just `name`, rather than first and last name. (Sorry @kevin-wei and @NerdyGirl537 and @adinneen and @drownedout , I know we just changed this at the last meeting). 

My reasoning for wanting to change it back is as follows:
a) A couple things (the signup page, most notably) require specifically whitelisting non-devise attributes in the User model. So this is a slightly more involved change than just changing some Mongo attributes. (We'll also need to change the devise `sign_up` view, and add any permitted fields to a hash in `ApplicationController`.)
b) There's also a privacy issue with firstname and lastname of CMs; this would be, I think, pretty unique among DCAF docs on the internet in that it would have firstname and lastname. Our Excel doc just does initials/nicknames for both CMs and patients, when DCAF talks about people on the blog it's firstname last initial, etc.

Sorry for not raising these earlier. If there's strenuous objection to this long term we should talk about it, but I'm going to revert it back for now for the sake of a) and b) above.

Fixes #39 