### PR TITLE
Call params

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -1,7 +1,7 @@
 class CallsController < ApplicationController
   def create
     c = Case.find(params[:id])
-    @call = c.calls.new(call_params) # TODO strong params
+    @call = c.calls.new(call_params)
 		if @call.save
 			redirect_to root_path
     else

--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -1,8 +1,7 @@
 class CallsController < ApplicationController
-
   def create
     c = Case.find(params[:id])
-    @call = c.calls.new(call_params)
+    @call = c.calls.new(call_params) # TODO strong params
 		if @call.save
 			redirect_to root_path
     else
@@ -12,8 +11,8 @@ class CallsController < ApplicationController
   end
 
   private
+
 	def call_params
 		params.require(:call).permit(:status)
 	end
-
 end

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -1,15 +1,15 @@
-<div class="modal" id="call-<%= c.patient.primary_phone %>">
+<div class="modal fade" tabindex="-1" role="dialog" id="call-<%= c.patient.primary_phone %>">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">
         <button type="button" class="close close-terms" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">Call <b><%= c.patient.name %></b> now</h4>
         <h4><%= c.patient.primary_phone %></h4>
-        <%= button_to "I reached the patient", calls_path(c, status: "Reached patient"), method: :post %>
+        <%= button_to "I reached the patient", calls_path(c, call: { status: 'Reached Patient'} ), method: :post %>
         </br>
-        <%= link_to "I left a voicemail for the patient", calls_path(c, status: "Left voicemail"), method: :post %>
+        <%= link_to "I left a voicemail for the patient", calls_path(c, call: { status: "Left voicemail" } ), method: :post %>
         </br>
-        <%= link_to "I couldn't reach the patient", calls_path(c, status: "Couldn't reach patient"), method: :post %>
+        <%= link_to "I couldn't reach the patient", calls_path(c, call: { status: "Couldn't reach patient" } ), method: :post %>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -32,13 +32,5 @@ class CallsControllerTest < ActionController::TestCase
         post :create, call: @call, id: @case
       end
     end
-
-    # TODO set up strong parameters for calls controller
-    it 'should reject other attributes besides status' do
-      assert_no_difference 'Case.find(@case).calls.count' do 
-        @call[:other] = "extraneous attribute"
-        post :create, call: @call, id: @case
-      end
-    end
   end
 end

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -21,14 +21,6 @@ class CallsControllerTest < ActionController::TestCase
       assert_response :redirect
     end
 
-    # If we have to look up the call through a case this test seems redundant
-    # I.e. I think the previous test also confirms the association
-    # it 'should associate the new call with a case' do
-    #   post :create, status: @call.status, id: @case
-    #   assert_equal Case.find(@case).calls.last.case, @case
-    #   assert_includes Case.find(@case).calls, Case.find(@case).calls.last
-    # end
-
     it 'should redirect to the root path afterwards' do
       post :create, call: @call, id: @case
       assert_redirected_to root_path
@@ -41,12 +33,12 @@ class CallsControllerTest < ActionController::TestCase
       end
     end
 
+    # TODO set up strong parameters for calls controller
     it 'should reject other attributes besides status' do
-      @call[:other] = "extraneous attribute"
-      post :create, call: @call, id: @case
-      assert_not_respond_to Case.find(@case).calls.last, :other
+      assert_no_difference 'Case.find(@case).calls.count' do 
+        @call[:other] = "extraneous attribute"
+        post :create, call: @call, id: @case
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
Resolves a params hash issue on the call log forms. 

PS to @ajohnson052: tl;dr you were right about strong params behavior. My mistake, sorry! It looks like the common testing strategy is to just make sure that other parameters get filtered out. 
