### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Colin Fleming.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ This repo has a `gh-pages` branch, currently used for displaying live pages. To 
 * Start the web server -- `$ jekyll serve --baseurl ''`
 * Navigate to `http://localhost:4000`
 * Make changes to the pages in the root directory or the assets in `_sass` and hack away!
+
+# License
+
+Made available under an MIT license. See `LICENSE.txt` for more info.

--- a/README.md
+++ b/README.md
@@ -65,18 +65,6 @@ To manage the dependencies and save us all some headache, we've Dockered this ap
 * Allow for MongoDB read/write permissions `$ sudo chmod 777 /data/db`
 * Start 'er up with `$ mongod`
 
-# Depreciated Readme stuff
-
-## Working With Jekyll 
-
-This repo has a `gh-pages` branch, currently used for displaying live pages. To contribute to those pages (this assumes you have ruby installed): 
-
-* clone it -- `$ git clone git@github.com:colinxfleming/dcaf_case_management.git`
-* Install the jekyll gem -- `$ gem install jekyll`
-* Start the web server -- `$ jekyll serve --baseurl ''`
-* Navigate to `http://localhost:4000`
-* Make changes to the pages in the root directory or the assets in `_sass` and hack away!
-
 # License
 
 Made available under an MIT license. See `LICENSE.txt` for more info.

--- a/civic.json
+++ b/civic.json
@@ -1,7 +1,7 @@
 {
     "name": "DCAF Case Manager", 
     "description": "A Rails-based case management system for ", 
-    "license": "", 
+    "license": "MIT", 
     "status": "Alpha", 
     "homepage": "http://casemanagerdemo.herokuapp.com", 
     "repository": "https://github.com/colinxfleming/dcaf_case_manager", 


### PR DESCRIPTION
Adds an MIT license and makes edits in the readme and the civic.json. 

@stvnrlly for yr review. 

Fixes #58 
