### PR TITLE
Hotfix - Call modal

### DIFF
--- a/app/views/pregnancies/_table_content.html.erb
+++ b/app/views/pregnancies/_table_content.html.erb
@@ -8,6 +8,6 @@
   <% else %>
     <td><%= link_to "Add", "/users/#{current_user.id}/add_pregnancy/#{p.id}", method: :patch, remote: true %></td>
   <% end %>
-  <td><%= link_to "Call", "#new_call", data: {toggle: "modal"} %></td>
+  <td><%= link_to "Call", "#call-#{p.patient.primary_phone}", data: {toggle: "modal"} %></td>
   <%= render partial: 'calls/new_call', locals: {p: p} %>
 </tr>


### PR DESCRIPTION
The modal identifier in the new call link wasn't lining up with the modals so the link didn't do anything. Now it brings up a new call corresponding with the patient!