### PR TITLE
Add controller test for users#add_pregnancy and users#remove_pregnancy

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :get_user_and_pregnancy
+  rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :bad_request }
 
   def add_pregnancy
     @user.pregnancies << @pregnancy
@@ -14,7 +15,7 @@ class UsersController < ApplicationController
   private 
 
   def get_user_and_pregnancy
-    @pregnancy = Pregnancy.find(params[:id])
-    @user = User.find(params[:user_id])
+    @pregnancy = Pregnancy.find params[:id]
+    @user = User.find params[:user_id]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
       end
     end
     resources :patients, only: [ :create ]
-    patch 'users/:user_id/add_pregnancy/:id', to: 'users#add_pregnancy'
-    patch 'users/:user_id/remove_pregnancy/:id', to: 'users#remove_pregnancy'
+    patch 'users/:user_id/add_pregnancy/:id', to: 'users#add_pregnancy', as: 'add_pregnancy'
+    patch 'users/:user_id/remove_pregnancy/:id', to: 'users#remove_pregnancy', as: 'remove_pregnancy'
     post 'search', to: 'pregnancies#search', defaults: { format: :js }
   end
   root :to => redirect('/users/sign_in')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
       end
     end
     resources :patients, only: [ :create ]
-    patch 'users/:user_id/add_pregnancy/:id', to: 'users#add_pregnancy', as: 'add_pregnancy'
-    patch 'users/:user_id/remove_pregnancy/:id', to: 'users#remove_pregnancy', as: 'remove_pregnancy'
+    patch 'users/:user_id/add_pregnancy/:id', to: 'users#add_pregnancy', as: 'add_pregnancy', defaults: { format: :js }
+    patch 'users/:user_id/remove_pregnancy/:id', to: 'users#remove_pregnancy', as: 'remove_pregnancy', defaults: { format: :js }
     post 'search', to: 'pregnancies#search', defaults: { format: :js }
   end
   root :to => redirect('/users/sign_in')

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,9 +2,18 @@ require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
   def setup
+    @user = create :user
+    sign_in @user
+    @patient_1 = create :patient, name: 'Susan Everyteen'
+    @pregnancy_1 = create :pregnancy, patient: @patient_1
+    @patient_2 = create :patient, name: 'Yolo Goat'
+    @pregnancy_2 = create :pregnancy, patient: @patient_2
   end
 
   describe 'add_pregnancy method' do
+    it 'should do a thing' do 
+      patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+    end
   end
 
   describe 'remove_pregnancy method' do 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
-  def setup
+  before do
     @user = create :user
     sign_in @user
     @patient_1 = create :patient, name: 'Susan Everyteen'
@@ -11,13 +11,15 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   describe 'add_pregnancy method' do
-    it 'should respond successfully' do 
+    before do 
       patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+    end
+
+    it 'should respond successfully' do 
       assert_response :success
     end
 
     it 'should add a patient to a users call list' do 
-      patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
       assert_equal @user.pregnancies.count, 1
       assert_difference '@user.pregnancies.count', 1 do
         patch :add_pregnancy, id: @pregnancy_2, user_id: @user, format: :js
@@ -25,16 +27,49 @@ class UsersControllerTest < ActionController::TestCase
       assert_equal @user.pregnancies.count, 2
     end
 
+    it 'should not adjust the count if a pregnancy is already in the list' do 
+      assert_no_difference '@user.pregnancies.count' do 
+        patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+      end
+    end
+
     it 'should should return bad request on sketch ids' do 
       patch :add_pregnancy, id: '12345678', user_id: @user, format: :js
       assert_response :bad_request
+      patch :add_pregnancy, id: @pregnancy_1, user_id: 'bronsonmissouri', format: :js
+      assert_response :bad_request
     end
-
   end
 
   describe 'remove_pregnancy method' do 
-  end
+    before do
+      patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+      patch :add_pregnancy, id: @pregnancy_2, user_id: @user, format: :js
+      patch :remove_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+    end
 
-  describe 'get_user_and_pregnancy method' do 
+    it 'should respond successfully' do 
+      assert_response :success
+    end
+
+    it 'should remove a pregnancy' do 
+      assert_difference '@user.pregnancies.count', -1 do 
+        patch :remove_pregnancy, id: @pregnancy_2, user_id: @user, format: :js
+      end
+    end
+
+    it 'should do nothing if the pregnancy is not currently in the call list' do 
+      assert_no_difference '@user.pregnancies.count' do 
+        patch :remove_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+      end
+      assert_response :success
+    end
+
+    it 'should should return bad request on sketch ids' do 
+      patch :remove_pregnancy, id: '12345678', user_id: @user, format: :js
+      assert_response :bad_request
+      patch :remove_pregnancy, id: @pregnancy_1, user_id: 'bronsonmissouri', format: :js
+      assert_response :bad_request
+    end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+  def setup
+  end
+
+  describe 'add_pregnancy method' do
+  end
+
+  describe 'remove_pregnancy method' do 
+  end
+
+  describe 'get_user_and_pregnancy method' do 
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -11,9 +11,25 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   describe 'add_pregnancy method' do
-    it 'should do a thing' do 
+    it 'should respond successfully' do 
       patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+      assert_response :success
     end
+
+    it 'should add a patient to a users call list' do 
+      patch :add_pregnancy, id: @pregnancy_1, user_id: @user, format: :js
+      assert_equal @user.pregnancies.count, 1
+      assert_difference '@user.pregnancies.count', 1 do
+        patch :add_pregnancy, id: @pregnancy_2, user_id: @user, format: :js
+      end
+      assert_equal @user.pregnancies.count, 2
+    end
+
+    it 'should should return bad request on sketch ids' do 
+      patch :add_pregnancy, id: '12345678', user_id: @user, format: :js
+      assert_response :bad_request
+    end
+
   end
 
   describe 'remove_pregnancy method' do 


### PR DESCRIPTION
Adds a few bells and whistles to the routes, a rescue_from block to the users controller in case a pregnancy or id isn't found, and some controller behavior tests for call list building methods. 

Thanks to @ajohnson052 for making these methods super easy to write tests for !

Fixes #125 