### PR TITLE
Add call creation

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -2,6 +2,7 @@ class CallsController < ApplicationController
   def create
     p = Pregnancy.find(params[:id])
     @call = p.calls.new(call_params)
+    @call.creating_user_id = current_user.id
 		if @call.save && params[:call][:status] == "Reached patient"
       redirect_to edit_pregnancy_path(p)
     elsif @call.save

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -13,4 +13,8 @@ class Call
   validates :status,  presence: true, 
                       inclusion: { in: allowed_statuses }
   validates :creating_user_id, presence: true
+
+  def user
+    User.find creating_user_id
+  end
 end

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -10,7 +10,7 @@ class Call
   field :creating_user_id, type: String
 	embedded_in :pregnancy
 
-	validates_presence_of :status
   validates :status,  presence: true, 
                       inclusion: { in: allowed_statuses }
+  validates :creating_user_id, presence: true
 end

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -3,8 +3,14 @@ class Call
 	include Mongoid::Timestamps
 	include Mongoid::History
 
+  allowed_statuses = ['Reached patient', 'Left voicemail', "Couldn't reach patient"]
+
 	field :status, type: String
+  # necessary because embedding things blows up belongs_to relationships
+  field :creating_user_id, type: String
 	embedded_in :pregnancy
 
 	validates_presence_of :status
+  validates :status,  presence: true, 
+                      inclusion: { in: allowed_statuses }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,5 +47,4 @@ class User
   validates_presence_of :email, :name
 
   has_many :pregnancies
-
 end

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class CallsControllerTest < ActionController::TestCase
-  def setup
-    @user = build :user
+  before do
+    @user = create :user
     sign_in @user
     @pregnancy = create :pregnancy
   end
@@ -10,31 +10,46 @@ class CallsControllerTest < ActionController::TestCase
   describe 'create method' do
     before do
       @call = attributes_for :call
+      post :create, call: @call, id: @pregnancy, format: :js
     end
 
     it 'should create and save a new call' do
       assert_difference 'Pregnancy.find(@pregnancy).calls.count', 1 do
-        post :create, call: @call, id: @pregnancy
+        post :create, call: @call, id: @pregnancy, format: :js
       end
-      assert_response :redirect
     end
 
     it 'should respond success if patient is not reached' do
-      call  = attributes_for :call, status: "Left voicemail"
+      call = attributes_for :call, status: "Left voicemail"
       post :create, call: call, id: @pregnancy, format: :js
       assert_response :success
     end
 
     it 'should redirect to the edit pregnancy path if patient is reached' do
-      post :create, call: @call, id: @pregnancy
+      post :create, call: @call, id: @pregnancy, format: :js
       assert_redirected_to edit_pregnancy_path(@pregnancy)
     end
 
-    it 'should not save if status is blank for some reason' do
-      @call[:status] = nil
-      assert_no_difference 'Pregnancy.find(@pregnancy).calls.count' do
-        post :create, call: @call, id: @pregnancy
+    it 'should render create.js.erb if patient is not reached or if could not reach' do
+      ['Left voicemail', "Couldn't reach patient"].each do |status|
+        @call[:status] = status
+        post :create, call: @call, id: @pregnancy, format: :js
+        assert_template 'calls/create'
       end
+    end
+
+    it 'should not save and flash an error if status is blank or bad for some reason' do
+      [nil, 'not a real status'].each do |bad_status|
+        @call[:status] = bad_status
+        assert_no_difference 'Pregnancy.find(@pregnancy).calls.count' do
+          post :create, call: @call, id: @pregnancy, format: :js
+        end
+        assert_redirected_to root_path
+      end
+    end
+
+    it 'should log the creating user' do
+      assert_equal Pregnancy.find(@pregnancy).calls.last.creating_user_id, @user.id.to_s
     end
   end
 end

--- a/test/factories/call.rb
+++ b/test/factories/call.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :call do
     pregnancy
     status "Reached patient"
+    creating_user_id 'xxee183c311c8897b0efb7zz'
   end
 end

--- a/test/models/call_test.rb
+++ b/test/models/call_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class CallTest < ActiveSupport::TestCase
+  before do 
+    @user = create :user
+    @pregnancy = create :pregnancy
+    @call = create :call, pregnancy: @pregnancy, creating_user_id: @user.id
+  end
+
+  it 'SHOULD SOUND THIS ALARM AS LONG AS EVERYTHING IS OKAY' do 
+    assert @call.valid?
+  end
+
+  describe 'basic validations' do
+    it 'should only allow certain statuses' do
+      [nil, 'not a status'].each do |bad_status|
+        @call.status = bad_status
+        refute @call.valid? 
+      end
+      ['Left voicemail', "Couldn't reach patient"].each do |status|
+        @call.status = status
+        assert @call.valid?
+      end
+    end
+
+    it 'should require a user id' do
+      @call.creating_user_id = nil
+      refute @call.valid?
+    end
+  end
+
+  describe 'relationships' do
+    it 'should be linkable to a pregnancy' do 
+      assert_equal @call.pregnancy, @pregnancy
+    end
+
+    it 'should be linkable to a user' do 
+      assert_equal @call.user, @user
+    end
+  end
+end


### PR DESCRIPTION
What started as tying calls to user became so much more. Adds a slew of controller and model tests for call, 

* Requires that a call be tied to a user
* Adjusts controller to fit that behavior
* Adds tests on the model and controller levels to confirm most of the call controller and object behaviors
* Adds a user method to get a call's creator
* Other assorted tidying

Fixes #155 