### PR TITLE
Add user to seedfile

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,9 @@
 Call.destroy_all
 Pregnancy.destroy_all
 Patient.destroy_all
+User.destroy_all
+
+user = User.create name: 'testuser', email: 'test@test.com', password: 'password', password_confirmation: 'password'
 
 10.times do |i|
   Patient.create({name: "Patient #{i}", primary_phone: "123-123-123#{i}"})


### PR DESCRIPTION
Spent some time troubleshooting a case when calls weren't saving -- apparently the issue was that calls without user ids were being considered invalid and preventing the entire document from saving. This is now a mongo behavior I know about. 

Anyway, here's an incremental improvement that came out of this -- adding a user to the seedfile!