### PR TITLE
README formatting tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ First things first: Make a copy of your own to wrench on! Go to `https://github.
 
 If you don't currently have Rails installed (or are on Windows), Cloud9 makes things WAY easier by letting you skip installation of Rails and MongoDB: 
 
-    Sign into `https://c9.io/` and create a new workspace
-    Clone from `git@github.com:{your_github_username}/dcaf_case_management.git` and select the Rails option
-    Once created, `$ bundle install` from the terminal
-    `$ mongod` to start MongoDB
-    Hit the `Run Project` button up top. (If the button is unresponsive, you may need select **Run -> Run With -> Rails Default** from the dropdown.)
+* Sign into `https://c9.io/` and create a new workspace
+* Clone from `git@github.com:{your_github_username}/dcaf_case_management.git` and select the Rails option
+* Once created, `bundle install` from the terminal
+* `mongod` to start MongoDB
+* Hit the `Run Project` button up top. (If the button is unresponsive, you may need select **Run -> Run With -> Rails Default** from the dropdown.)
 
 If you do prefer a local environment, do the following: 
 
-    # Install Ruby, Rails and MongoDB (An easy rails installer is [here](http://railsinstaller.org/en); MongoDB setup instructions are below)
-    `$ git clone git@github.com:{your_github_username}/dcaf_case_management.git && cd dcaf_case_management`
-    `$ bundle install`
-    `$ rails server`
-    # navigate your browser to `http://localhost:3000`
+* Install Ruby, Rails and MongoDB (An easy rails installer is [here](http://railsinstaller.org/en); MongoDB setup instructions are below)
+* `git clone git@github.com:{your_github_username}/dcaf_case_management.git && cd dcaf_case_management`
+* `bundle install`
+* `rails server`
+* Navigate your browser to `http://localhost:3000`
 
 ## For designers
 The design team has created a working InVision prototype for iteration, [here](https://projects.invisionapp.com/share/6757W6WFJ). We need help furthering the wireframes in InVision beyond the "Submit Pledge" button, as well as designing a usability testing plan for the app. 
@@ -55,15 +55,15 @@ Current UX and wireframe assets are available here:
 ## Dockerizing
 
 To manage the dependencies and save us all some headache, we've Dockered this app. If you're docker-savvy, you can run the following to fire up mongo and the rails server: 
-* `$ docker-compose build && docker-compose up`
+* `docker-compose build && docker-compose up`
 
 ## Setting up MongoDB
 
-* Install MongoDB locally if you haven't (`$ brew install mongodb`, for example, or the [linux instructions](https://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/))
-* `$ bundle install` to install necessary gems
-* Create a folder in the root directory for the MongoDB database. `$ sudo mkdir -p /data/db`
-* Allow for MongoDB read/write permissions `$ sudo chmod 777 /data/db`
-* Start 'er up with `$ mongod`
+* Install MongoDB locally if you haven't (`brew install mongodb`, for example, or the [linux instructions](https://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/))
+* `bundle install` to install necessary gems
+* Create a folder in the root directory for the MongoDB database. `sudo mkdir -p /data/db`
+* Allow for MongoDB read/write permissions `sudo chmod 777 /data/db`
+* Start 'er up with `mongod`
 
 # License
 


### PR DESCRIPTION
There wasn't an issue for this, just some things I noticed when going through the readme.
Turns instructions into bulleted lists instead of code blocks, removes `$` from beginning of terminal commands for easier copy/pasting