### PR TITLE
Alter routes

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -21,6 +21,6 @@ class CallsController < ApplicationController
   end
 
   def find_pregnancy
-    @pregnancy = Pregnancy.find params[:id]
+    @pregnancy = Pregnancy.find params[:pregnancy_id]
   end
 end

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -5,11 +5,11 @@
         <button type="button" class="close close-terms" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">Call <b><%= p.patient.name %></b> now</h4>
         <h4><%= p.patient.primary_phone %></h4>
-        <%= button_to "I reached the patient", calls_path(p, call: { status: 'Reached patient'} ), method: :post, class: 'btn btn-primary' %>
+        <%= button_to "I reached the patient", pregnancy_calls_path(p, call: { status: 'Reached patient'} ), method: :post, class: 'btn btn-primary' %>
         </br>
-        <%= link_to "I left a voicemail for the patient", calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true %>
+        <%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true %>
         </br>
-        <%= link_to "I couldn't reach the patient", calls_path(p, call: { status: "Couldn't reach patient" } ), method: :post, remote: true %>
+        <%= link_to "I couldn't reach the patient", pregnancy_calls_path(p, call: { status: "Couldn't reach patient" } ), method: :post, remote: true %>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,8 @@ Rails.application.routes.draw do
     get 'dashboard', to: 'dashboards#index', as: 'dashboard'
     post 'search', to: 'dashboards#search', defaults: { format: :js }
     resources :pregnancies, only: [ :edit, :update ] do
-      member do
-        resources :calls, only: [ :create ]
-        resources :notes, only: [ :create, :update ]
-      end
+      resources :calls, only: [ :create ]
+      resources :notes, only: [ :create, :update ]
     end
     resources :patients, only: [ :create ]
     patch 'users/:user_id/add_pregnancy/:id', to: 'users#add_pregnancy', as: 'add_pregnancy', defaults: { format: :js }

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -10,18 +10,18 @@ class CallsControllerTest < ActionController::TestCase
   describe 'create method' do
     before do
       @call = attributes_for :call
-      post :create, id: @pregnancy, call: @call, format: :js
+      post :create, pregnancy_id: @pregnancy.id, call: @call, format: :js
     end
 
     it 'should create and save a new call' do
       assert_difference 'Pregnancy.find(@pregnancy).calls.count', 1 do
-        post :create, call: @call, id: @pregnancy, format: :js
+        post :create, call: @call, pregnancy_id: @pregnancy.id, format: :js
       end
     end
 
     it 'should respond success if patient is not reached' do
       call = attributes_for :call, status: 'Left voicemail'
-      post :create, call: call, id: @pregnancy, format: :js
+      post :create, call: call, pregnancy_id: @pregnancy.id, format: :js
       assert_response :success
     end
 
@@ -32,7 +32,7 @@ class CallsControllerTest < ActionController::TestCase
     it 'should render create.js.erb if patient is not reached or if could not reach' do
       ['Left voicemail', "Couldn't reach patient"].each do |status|
         @call[:status] = status
-        post :create, call: @call, id: @pregnancy, format: :js
+        post :create, call: @call, pregnancy_id: @pregnancy.id, format: :js
         assert_template 'calls/create'
       end
     end
@@ -41,7 +41,7 @@ class CallsControllerTest < ActionController::TestCase
       [nil, 'not a real status'].each do |bad_status|
         @call[:status] = bad_status
         assert_no_difference 'Pregnancy.find(@pregnancy).calls.count' do
-          post :create, call: @call, id: @pregnancy, format: :js
+          post :create, call: @call, pregnancy_id: @pregnancy.id, format: :js
         end
         assert_redirected_to root_path
       end


### PR DESCRIPTION
In our routes, we had resources for calls and notes in a `member` block, which was rendering our routes as follows:

```
                   calls POST   /pregnancies/:id/calls(.:format)               calls#create
                   notes POST   /pregnancies/:id/notes(.:format)               notes#create
                    note PATCH  /pregnancies/:id/notes/:id(.:format)           notes#update
                         PUT    /pregnancies/:id/notes/:id(.:format)           notes#update
```
Which in turn was making it impossible to build the update route for `notes`, since there were two `params[:id]`s. 

This takes that out, which makes the routing behave as follows: 

```
         pregnancy_calls POST   /pregnancies/:pregnancy_id/calls(.:format)     calls#create
         pregnancy_notes POST   /pregnancies/:pregnancy_id/notes(.:format)     notes#create
          pregnancy_note PATCH  /pregnancies/:pregnancy_id/notes/:id(.:format) notes#update
                         PUT    /pregnancies/:pregnancy_id/notes/:id(.:format) notes#update
```

Also makes a few changes so that the tests pass. 