### PR TITLE
Add standard templates for pull requests and bug logging

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,7 @@
+(If you are reporting a bug, please fill out the following details so that we can expedite resolution! If you aren't reporting a bug, go ahead and delete all this and fill out your issue as normal. Thanks! - @colinxfleming, @mebates, and @adinneen)
+
+* What are you trying to do? ("When I do X, I expect Y to happen.")
+
+* What's happening instead? ("Instead, Z happens")
+
+* Please include any other information we might find useful (screenshots, error messages, etc).

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,7 +1,11 @@
 (If you are reporting a bug, please fill out the following details so that we can expedite resolution! If you aren't reporting a bug, go ahead and delete all this and fill out your issue as normal. Thanks! - @colinxfleming, @mebates, and @adinneen)
 
-* What are you trying to do? ("When I do X, I expect Y to happen.")
+* What screen are you on? (ex: "My url is: ...")
 
-* What's happening instead? ("Instead, Z happens")
+* What are you trying to do? (ex: "I'm trying to save a call.")
+
+* What should be happening? (ex: "It should redirect me to the dashboard.")
+
+* What's happening instead? (ex: "It's giving an error message.")
 
 * Please include any other information we might find useful (screenshots, error messages, etc).

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,5 +6,5 @@ This pull request makes the following changes:
 * (etc)
 
 It relates to the following issue #s: 
-* #X
-* etc
+* Issue #X
+* Issue #Y

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,10 @@
+I rule and have completed some work on Case Manager that's ready for review!
+
+This pull request makes the following changes:
+* (your change here)
+* (another change here)
+* (etc)
+
+It relates to the following issue #s: 
+* #X
+* etc


### PR DESCRIPTION
Adds a standard form that will populate on initializing pull requests and issues, to encourage more fully fleshed out decisions. Future us will thank us. 

@mebates @adinneen let me know if you have any feedback! Can probably wait until the next full meeting. 

Fixes #206 