### PR TITLE
Restrict phone fields to a single number #225

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -9,9 +9,12 @@ class Patient
   validates_presence_of :name, :primary_phone
 
   field :name, type: String # strip
-  field :primary_phone, type: String , length{ :maximum => 12}# validate
+  field :primary_phone, type: String 
+  validates :primary_phone, length:{maximum:12}
   field :secondary_person, type: String
-  field :secondary_phone, type: String ,:maximum => 12
+  field :secondary_phone, type: String 
+  validates :secondary_phone, length:{maximum:12}
+
 
   track_history on: fields.keys + [:updated_by_id],
                 version_field: :version,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -15,7 +15,6 @@ class Patient
   field :secondary_phone, type: String 
   validates :secondary_phone, length:{maximum:12}
 
-
   track_history on: fields.keys + [:updated_by_id],
                 version_field: :version,
                 track_create: true,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -9,7 +9,7 @@ class Patient
   validates_presence_of :name, :primary_phone
 
   field :name, type: String # strip
-  field :primary_phone, type: String , :maximum => 12 # validate
+  field :primary_phone, type: String , length{ :maximum => 12}# validate
   field :secondary_person, type: String
   field :secondary_phone, type: String ,:maximum => 12
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -9,9 +9,9 @@ class Patient
   validates_presence_of :name, :primary_phone
 
   field :name, type: String # strip
-  field :primary_phone, type: String # validate
+  field :primary_phone, type: String , :maximum => 12 # validate
   field :secondary_person, type: String
-  field :secondary_phone, type: String
+  field :secondary_phone, type: String ,:maximum => 12
 
   track_history on: fields.keys + [:updated_by_id],
                 version_field: :version,


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* add length validations(12 characters) to the patient.rb primary and secondary phone fields


It relates to the following issue #s: 
* Fixes #225 
