### PR TITLE
Fixes spelling error and adds a link to the Docker install page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 
 ### Docker
 
-We've dockerized this app, to manage the dependencies and save us all the headahce. If you've got Docker installed already, you can be up and running with three commands:
+We've dockerized this app, to manage the dependencies and save us all the headache. If you've got [Docker installed already] (https://docs.docker.com/engine/installation/), you can be up and running with three commands:
 * `docker-compose build # to install the dependencies` 
 * `docker-compose run web rake db:seed # to populate the database`
 * `docker-compose up`


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* "headahce" => "headache"
* Adds a link to the [Docker install page](https://docs.docker.com/engine/installation/)

It relates to the following issue #s: 
* Not applicable to a specific issue, but Code For DC Project Co-Leads are doing a Readme Audit of projects Readme's to ensure install instructions allow newcomers to get a local development environment of our applications spun up quickly. Was able to get the app working with the Docker instructions and figured adding a link to install Docker would help newcomers a tad more 😃 .

