### PR TITLE
Add separate tests for helpers

### DIFF
--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -4,6 +4,6 @@ module PregnanciesHelper
   end
 
   def days_options
-    (0..6).map { |i| ["#{i} days", i] }
+    (0..6).map { |i| [pluralize(i, 'day'), i] }
   end
 end

--- a/test/helpers/last_menstrual_period_helper.rb
+++ b/test/helpers/last_menstrual_period_helper.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class LastMenstrualPeriodHelperTest < ActionView::TestCase
+  before do
+    @patient = create :patient, created_by: @user
+    @pregnancy = create :pregnancy,
+                        last_menstrual_period_weeks: 9,
+                        last_menstrual_period_days: 2,
+                        initial_call_date: 2.days.ago,
+                        created_by: @user
+  end
+
+  describe 'last_menstrual_period_display' do
+    it 'should return nil if LMP weeks is not set' do
+      @pregnancy.last_menstrual_period_weeks = nil
+      assert_nil @pregnancy.last_menstrual_period_display
+    end
+
+    it 'should return LMP in weeks and days' do
+      assert_equal @pregnancy.last_menstrual_period_display, '9 weeks, 4 days'
+    end
+  end
+
+  describe 'last_menstrual_period_display_short' do
+    it 'should return nil if LMP weeks is not set' do
+      @pregnancy.last_menstrual_period_weeks = nil
+      assert_nil @pregnancy.last_menstrual_period_display_short
+    end
+
+    it 'should return shorter LMP in weeks and days' do
+      assert_equal @pregnancy.last_menstrual_period_display_short, '9w 4d'
+    end
+  end
+
+  describe 'last_menstrual_period_now' do
+    it 'should return nil if LMP weeks is not set' do
+      @pregnancy.last_menstrual_period_weeks = nil
+      assert_nil @pregnancy.send(:last_menstrual_period_now)
+    end
+
+    it 'should be equivalent to LMP on date - Time.zone.today' do
+      assert_equal  @pregnancy.send(:last_menstrual_period_now),
+                    @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today)
+    end
+  end
+
+  describe 'last_menstrual_period_on_date' do
+    it 'should nil out if LMP weeks is not set' do
+      @pregnancy.last_menstrual_period_weeks = nil
+      assert_nil @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today)
+    end
+
+    it 'should accurately calculate LMP on a given date' do
+      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 67
+      assert_equal @pregnancy.send(:last_menstrual_period_on_date, 5.days.from_now.to_date), 72
+
+      @pregnancy.initial_call_date = 4.days.ago
+      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 69
+
+      @pregnancy.last_menstrual_period_weeks = 10
+      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 76
+
+      @pregnancy.last_menstrual_period_days = 6
+      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 80
+    end
+  end
+end

--- a/test/helpers/last_menstrual_period_helper_test.rb
+++ b/test/helpers/last_menstrual_period_helper_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class LastMenstrualPeriodHelperTest < ActionView::TestCase
   before do
+    @user = create :user
     @patient = create :patient, created_by: @user
     @pregnancy = create :pregnancy,
                         last_menstrual_period_weeks: 9,

--- a/test/helpers/pregnancies_helper_test.rb
+++ b/test/helpers/pregnancies_helper_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class PregnanciesHelperTest < ActionView::TestCase
+  describe 'weeks_options' do
+    it 'should pluralize properly' do
+      assert_equal '1 week', weeks_options.first[0]
+      assert_equal '2 weeks', weeks_options.second[0]
+      assert_equal 1, weeks_options.select { |x| /week$/.match x[0] }.count
+    end
+
+    it 'should have 30 entries' do
+      assert_equal 30, weeks_options.count
+    end
+  end
+
+  describe 'days_options' do
+    it 'should pluralize properly' do
+      assert_equal '0 days', days_options.first[0]
+      assert_equal '1 day', days_options.second[0]
+      assert_equal '2 days', days_options.third[0]
+      assert_equal 1, days_options.select { |x| /day$/.match x[0] }.count
+    end
+
+    it 'should have 7 entries' do
+      assert_equal 7, days_options.count
+    end
+  end
+end

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -89,59 +89,6 @@ class PregnancyTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'last menstrual period helper methods' do
-    before do
-      @patient = create :patient, created_by: @user
-      @pregnancy = create :pregnancy, last_menstrual_period_weeks: 9, last_menstrual_period_days: 2, initial_call_date: 2.days.ago, created_by: @user
-    end
-
-    it 'LMP on date - should nil out if LMP weeks is not set' do
-      @pregnancy.last_menstrual_period_weeks = nil
-      assert_nil @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today)
-    end
-
-    it 'LMP on date - should accurately calculate LMP on a given date' do
-      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 67
-      assert_equal @pregnancy.send(:last_menstrual_period_on_date, 5.days.from_now.to_date), 72
-
-      @pregnancy.initial_call_date = 4.days.ago
-      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 69
-
-      @pregnancy.last_menstrual_period_weeks = 10
-      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 76
-
-      @pregnancy.last_menstrual_period_days = 6
-      assert_equal @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today), 80
-    end
-
-    it 'LMP now - should return nil if LMP weeks is not set' do
-      @pregnancy.last_menstrual_period_weeks = nil
-      assert_nil @pregnancy.send(:last_menstrual_period_now)
-    end
-
-    it 'LMP now - should be equivalent to LMP on date - Time.zone.today' do
-      assert_equal @pregnancy.send(:last_menstrual_period_now), @pregnancy.send(:last_menstrual_period_on_date, Time.zone.today)
-    end
-
-    it 'LMP display - should return nil if LMP weeks is not set' do
-      @pregnancy.last_menstrual_period_weeks = nil
-      assert_nil @pregnancy.last_menstrual_period_display
-    end
-
-    it 'LMP display - should return LMP in weeks and days' do
-      assert_equal @pregnancy.last_menstrual_period_display, '9 weeks, 4 days'
-    end
-
-    it 'LMP display short - should return nil if LMP weeks is not set' do
-      @pregnancy.last_menstrual_period_weeks = nil
-      assert_nil @pregnancy.last_menstrual_period_display_short
-    end
-
-    it 'LMP display short - should return shorter LMP in weeks and days' do
-      assert_equal @pregnancy.last_menstrual_period_display_short, '9w 4d'
-    end
-  end
-
   describe 'mongoid attachments' do
     it 'should have timestamps from Mongoid::Timestamps' do
       [:created_at, :updated_at].each do |field|


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds test files for helper methods, rather than doing everything in the model. Gotta bump that code coverage up!

This pull request makes the following changes:
* Moves LMP Helper methods into their own test, and removes them from the pregnancy model test
* Adds tests for the display helper methods in `pregnancies_helper`

It relates to the following issue #s: 
* Fixes #297 
