### PR TITLE
adjust so that docker-compose run web rake test works

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -131,7 +131,7 @@ test:
     default:
       database: dcaf_case_management_test
       hosts:
-        - localhost:27017
+        - '<%= ENV['mongohost'] %>:<%= ENV['mongoport'] %>'
       options:
         read:
           mode: :primary


### PR DESCRIPTION
Fix a small stupid config bug that was making the test suite eat mud when you tried to run it from within `docker-compose`. 