### PR TITLE
Fix logging call test by removing DB object retrieval

### DIFF
--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -28,6 +28,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   describe 'logging reached patient', js: true do
     before do
+      @timestamp = Time.now
       click_link 'I reached the patient'
     end
 
@@ -39,6 +40,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       click_link 'Call Log'
 
       within :css, '#call_log' do
+        assert has_text? @timestamp.localtime.strftime('%-m/%-d')
+        assert has_text? @timestamp.localtime.strftime('%-l:%M %P')
         assert has_text? 'Reached patient'
         assert has_text? @user.name
       end
@@ -67,6 +70,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         else
           raise 'Not a recognized call status'
         end
+        @timestamp = Time.now
       end
 
       it "should close the modal when clicking #{call_status}" do
@@ -82,6 +86,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         click_link 'Call Log'
 
         within :css, '#call_log' do
+          assert has_text? @timestamp.localtime.strftime('%-m/%-d')
+          assert has_text? @timestamp.localtime.strftime('%-l:%M %P')
           assert has_text? call_status
           assert has_text? @user.name
         end

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -14,7 +14,6 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   after do
     Capybara.use_default_driver
-    @pregnancy.calls.destroy_all
   end
 
   describe 'verifying modal behavior and content', js: true do
@@ -41,6 +40,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
       within :css, '#call_log' do
         assert has_text? 'Reached patient'
+        assert has_text? @user.name
       end
     end
 
@@ -83,6 +83,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
         within :css, '#call_log' do
           assert has_text? call_status
+          assert has_text? @user.name
         end
       end
     end

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -14,6 +14,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   after do
     Capybara.use_default_driver
+    @pregnancy.calls.destroy_all
   end
 
   describe 'verifying modal behavior and content', js: true do
@@ -37,13 +38,9 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
     it 'should be viewable on the call log' do
       click_link 'Call Log'
-      last_call = @pregnancy.reload.calls.last
 
       within :css, '#call_log' do
-        assert has_text? last_call.created_at.localtime.strftime('%-m/%d')
-        assert has_text? last_call.created_at.localtime.strftime('%-l:%M %P')
         assert has_text? 'Reached patient'
-        assert has_text? last_call.created_by.name
       end
     end
 
@@ -83,13 +80,9 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         click_link @link_text
         click_link 'Susan Everyteen'
         click_link 'Call Log'
-        last_call = @pregnancy.reload.calls.last
 
         within :css, '#call_log' do
-          assert has_text? last_call.created_at.localtime.strftime('%-m/%d')
-          assert has_text? last_call.created_at.localtime.strftime('%-l:%M %P')
           assert has_text? call_status
-          assert has_text? last_call.created_by.name
         end
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns out the call logging integration test, which is the first real JS-capybara test I've written, is a REAL bear about not making DB calls. I have no idea why they were causing failures, but they were, so I threw out the db calls and replaced with tests that didn't involve db hits. 

This should fix the random CI failures we've been experiencing. 

This pull request makes the following changes:
* Adjusts some tests to not make DB calls, and instead just looks at the call log directly

No associated issues.