### PR TITLE
fixed problem with grid on new pregnancies partial

### DIFF
--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -10,6 +10,10 @@ $font-size: 17px;
   padding: 15px 0;
 }
 
+.voicemailOk{
+    text-align:center;
+  
+}
 
 .hide-label{
   label{

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -2,27 +2,35 @@
 <%= bootstrap_form_for pregnancy do |f| %>
 
   <%= f.fields_for patient do |p| %>
-    <div class="col-md-2">
-      <%= p.text_field :primary_phone, label: "Phone Number" %>
+
+
+<div class="col-md-3">
+    <div class="col-md-6">
+      <%= p.text_field :primary_phone, label: "Number" %>
     </div>
-    <div class="col-md-2">
-      <%= p.text_field :name, label: "First and Last Name" %>
+    <div class="col-md-6">
+      <%= p.text_field :name, label: "Name" %>
     </div>
+  </div>
   <% end %>
 
-  <div class="col-md-2">
-    <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, pregnancy.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off' %>
-  </div>
+  <div class="col-md-3">
 
-  <div class="col-md-2 hide-label">
-    <%= f.select :last_menstrual_period_days, options_for_select(days_options, pregnancy.last_menstrual_period_days ), label: '.', autocomplete: 'off' %>
-  </div>
+    <div class="col-md-6">
+      <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, pregnancy.last_menstrual_period_weeks ), label: 'LMP', autocomplete: 'off' %>
+    </div>
+
+    <div class="col-md-6 hide-label">
+      <%= f.select :last_menstrual_period_days, options_for_select(days_options, pregnancy.last_menstrual_period_days ), label: 'LMP', autocomplete: 'off' %>
+    </div>
+
+</div>
 
   <div class="col-md-2">
     <%= f.date_field :initial_call_date, label: "Initial Call Date" %>
   </div>
 
-  <div class="col-md-2">
+  <div class="col-md-2 voicemailOk">
     <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
     <%= f.check_box :voicemail_ok, label: 'Yes' %> <!-- TODO add bootstrap toggle -->
     <% end %>


### PR DESCRIPTION
Fixed grid for now so that it will all stay on the same line. HOWEVER I had to change "First and Last Name" back to "Name" to save space, and "Phone Number" to "number". Will need to return back to this to potentially move some form elements to another row.