### PR TITLE
Finish currentdate in patient creation form

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -11,7 +11,7 @@ class DashboardsController < ApplicationController
     end
     @patient = Patient.new
     @pregnancy = @patient.pregnancies.new
-    @date=Time.now.to_date
+    @today = Time.zone.today.to_date
 
     respond_to { |format| format.js }
   end

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="col-md-2">
-    <%= f.date_field :initial_call_date, label: "Initial Call Date", value: @date %>
+    <%= f.date_field :initial_call_date, label: "Initial Call Date", value: @today %>
   </div>
 
   <div class="col-md-2">


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Picks up @Nico-ehs work in #288 , and edits a variable name for readability.

This pull request makes the following changes:
* Renames a date variable to `@today`
* Sets a default date in new patient creation form

It relates to the following issue #s: 
* Fixes #288 

Thanks for your work on this @Nico-ehs !