### PR TITLE
move quality to all groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'bson_ext'
 gem 'figaro'
 gem 'bootstrap_form'
 gem 'bootstrap_form-datetimepicker'
+gem 'quality', require: false
 
 group :development do
   gem 'web-console', '~> 2.0'
@@ -31,7 +32,6 @@ group :development, :test do
   # better error handling
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'quality', require: false
 end
 
 group :test do


### PR DESCRIPTION
`quality` gem needs to be in non-just dev groups so it doesn't break the CircleCI post deploy hook :(, so implementing this hotfix of moving a gem out of `group :development, :test`.
