### PR TITLE
Add integration test for pregnancy edit view section clicking

### DIFF
--- a/app/views/pregnancies/_patient_dashboard.html.erb
+++ b/app/views/pregnancies/_patient_dashboard.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-4" >
   <%= f.fields_for pregnancy.patient do |p| %>
-    <%= p.text_field :name, label: 'First and Last Name', autocomplete: 'off' %>
+    <%= p.text_field :name, label: 'First and last name', autocomplete: 'off' %>
     <%= p.text_field :primary_phone, label: 'Phone number', autocomplete: 'off' %>
   <% end %>
 </div>

--- a/test/integration/audit_trail_logging_test.rb
+++ b/test/integration/audit_trail_logging_test.rb
@@ -15,7 +15,7 @@ class AuditTrailLoggingTest < ActionDispatch::IntegrationTest
       assert_equal @patient.history_tracks.count, 1
       assert_equal @patient.created_by, @user
       assert_equal page.find(:id, 'pregnancy_patient_name').value, 'tester'
-      fill_in 'Name', with: 'changed'
+      fill_in 'First and last name', with: 'changed'
       click_button 'TEMP: SAVE INFORMATION'
       @patient.reload
       assert_equal @patient.name, 'changed'
@@ -25,7 +25,7 @@ class AuditTrailLoggingTest < ActionDispatch::IntegrationTest
       log_in_as @user2
       visit edit_pregnancy_path(@pregnancy)
       assert_equal page.find(:id, 'pregnancy_patient_name').value, 'changed'
-      fill_in 'Name', with: 'more change'
+      fill_in 'First and last name', with: 'more change'
       click_button 'TEMP: SAVE INFORMATION'
       @patient.reload
       assert_equal @patient.name, 'more change'

--- a/test/integration/show_pregnancy_information_test.rb
+++ b/test/integration/show_pregnancy_information_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class ShowPregnancyInformationTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+    @patient = create :patient, name: 'Susan Everyteen'
+    @pregnancy = create :pregnancy, patient: @patient
+    @user = create :user
+    log_in_as @user
+    visit edit_pregnancy_path(@pregnancy)
+  end
+
+  describe 'clicking between sections to see information' do
+    it 'should show the patient dashboard on open' do
+      within :css, '#patient_dashboard' do
+        assert has_text? 'First and last name'
+        assert has_text? 'LMP at intake'
+        assert has_text? 'Appointment date'
+        assert has_text? 'Phone number'
+        assert has_text? 'Status'
+      end
+    end
+
+    it 'should have everything in the sidebar' do
+      within :css, '#menu' do
+        assert has_link? 'Abortion Information'
+        assert has_link? 'Patient Information'
+        assert has_link? 'Change Log'
+        assert has_link? 'Call Log'
+        assert has_link? 'Notes'
+      end
+    end
+
+    it 'should show abortion information on open' do
+      within :css, '#sections' do
+        assert has_text? 'Abortion information'
+        assert has_text? 'Clinic details'
+        assert has_text? 'Cost details'
+      end
+    end
+
+    it 'should let you click to patient information' do
+      click_link 'Patient Information'
+      within :css, '#sections' do
+        refute has_text? 'Abortion information'
+        assert has_text? 'Patient information'
+      end
+    end
+
+    it 'should let you click to the change log' do
+      click_link 'Change Log'
+      within :css, '#sections' do
+        refute has_text? 'Abortion information'
+        assert has_text? 'Patient history'
+      end
+    end
+
+    it 'should let you click to the call log' do
+      click_link 'Call Log'
+      within :css, '#sections' do
+        refute has_text? 'Abortion information'
+        assert has_text? 'Call Log'
+      end
+    end
+
+    it 'should let you click to the notes' do
+      click_link 'Notes'
+      within :css, '#sections' do
+        refute has_text? 'Abortion information'
+        assert has_text? 'Notes'
+      end
+    end
+
+    it 'should let you click back to abortion information' do
+      click_link 'Notes'
+      within(:css, '#sections') { refute has_text? 'Abortion information' }
+      click_link 'Abortion Information'
+      within(:css, '#sections') { assert has_text? 'Abortion information' }
+    end
+  end
+end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -11,7 +11,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
   describe 'changing patient dashboard information' do
     before do
-      fill_in 'Name', with: 'Susie Everyteen 2'
+      fill_in 'First and last name', with: 'Susie Everyteen 2'
       find('#pregnancy_last_menstrual_period_weeks').select '5 weeks'
       find('#pregnancy_last_menstrual_period_days').select '2 days'
       # fill_in 'Appointment date', with: '12/20/2016' PUNT
@@ -23,7 +23,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
     it 'should alter the information' do
       within :css, '#patient_dashboard' do
-        assert has_field?('Name', with: 'Susie Everyteen 2')
+        assert has_field?('First and last name', with: 'Susie Everyteen 2')
         assert_equal find('#pregnancy_last_menstrual_period_weeks').value, '5'
         assert_equal find('#pregnancy_last_menstrual_period_days').value, '2'
         # assert has_field?('Appointment date', with: '12/20/2016') PUNT


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds an integration test for switching between sections in the pregnancy edit view
* Fixes a few scrub fields in integration tests that were failing

It relates to the following issue #s: 
* Fixes #101 
