### PR TITLE
force ssl in config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* force ssl in production

It relates to the following issue #s: 
* Deals with #327  Rails side

see notes http://www.eq8.eu/blogs/14-config-force_ssl-is-different-than-controller-force_ssl
(can be done controller side if not needed for whole site)