### PR TITLE
Add Codecov and test coverage badge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :test do
   gem 'poltergeist'
   gem 'simplecov', require: false
   gem 'launchy'
+  gem 'codecov', require: false
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
       sexp_processor
     codeclimate-engine-rb (0.3.1)
       virtus (~> 1.0)
+    codecov (0.1.5)
+      json
+      simplecov
+      url
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -338,6 +342,7 @@ GEM
     unicorn (5.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    url (0.3.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -370,6 +375,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
+  codecov
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise (~> 3.5, >= 3.5.10)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DCAF Case Manager
 
 [![CircleCI](https://circleci.com/gh/colinxfleming/dcaf_case_management.svg?style=shield)](https://circleci.com/gh/colinxfleming/dcaf_case_management)
+[![codecov](https://codecov.io/gh/colinxfleming/dcaf_case_management/branch/master/graph/badge.svg)](https://codecov.io/gh/colinxfleming/dcaf_case_management)
 
 [A deployed demo version of what's in the master branch is at: http://dcaf-cmapp-staging.herokuapp.com/](http://dcaf-cmapp-staging.herokuapp.com/)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,9 @@
 require 'simplecov'
 SimpleCov.start 'rails'
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

18F guide recommends having at least 90% test coverage, and also I want to brag to other projects about how well tested this project is, so I'm adding a codecov badge and configs.

This pull request makes the following changes:
* Adds `codecov` gem
* Adds codecov badge to readme, for showing off
