### PR TITLE
Fix most CI false flag failures

### DIFF
--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -4,23 +4,23 @@
 			<div class="info-form-left col-sm-12">
 				<h2>Notes</h2>
 				<%= bootstrap_form_for [pregnancy, note] do |f| %>
-				<%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
-				<%= f.submit class: "btn btn-primary"  %>
+					<%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
+					<%= f.submit class: "btn btn-primary"  %>
 				<% end %>
 			</div>
 		</div>
 	</div>
-	<table class="table border-side">
+	<table class="table border-side" id='notes_log'>
 		<tbody>
 			<% pregnancy.notes.order('created_at DESC').each do |note| %>
-			<tr>
-				<th><%= note.created_at.getlocal.strftime("%-m/%-d") %></th>
-				<th><%= note.created_at.getlocal.strftime("%l:%M %P") %></th>
-				<th><%= note.created_by.name %></td>
-			</tr>
-			<tr>
-				<td><%= note.full_text %></td>
-			</tr>
+				<tr>
+					<th><%= note.created_at.getlocal.strftime("%-m/%-d") %></th>
+					<th><%= note.created_at.getlocal.strftime("%l:%M %P") %></th>
+					<th><%= note.created_by.name %></td>
+				</tr>
+				<tr>
+					<td><%= note.full_text %></td>
+				</tr>
 			<% end %>
 		<tbody>
 	</table>

--- a/test/integration/dashboard_link_test.rb
+++ b/test/integration/dashboard_link_test.rb
@@ -25,7 +25,7 @@ class DashboardLinkTest < ActionDispatch::IntegrationTest
     end
 
     it 'should direct the user to the dashboard' do
-      click_link 'Dashboard'
+      find('a', text: 'Dashboard').click
       assert_equal current_path, authenticated_root_path
       refute has_link? 'Dashboard', href: authenticated_root_path
     end

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -28,16 +28,17 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   describe 'logging reached patient', js: true do
     before do
-      @timestamp = Time.now
-      click_link 'I reached the patient'
+      @timestamp = Time.zone.now
+      find('a', text: 'I reached the patient').click
     end
 
     it 'should redirect to the edit view when a patient has been reached' do
+      has_text? 'Submit pledge' # wait for the page to load
       assert_equal current_path, edit_pregnancy_path(@pregnancy)
     end
 
     it 'should be viewable on the call log' do
-      click_link 'Call Log'
+      find('a', text: 'Call Log').click
 
       within :css, '#call_log' do
         assert has_text? @timestamp.localtime.strftime('%-m/%-d')
@@ -53,7 +54,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       click_button 'Search'
       find("a[href='#call-123-123-1234']").click
       click_link 'I reached the patient'
-      click_link 'Call Log'
+      find('a', text: 'Call Log').click
       within :css, '#call_log' do
         assert has_content? 'Reached patient', count: 2
       end
@@ -81,6 +82,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       end
 
       it "should be visible on the call log after clicking #{call_status}" do
+        assert_equal current_path, authenticated_root_path
         visit edit_pregnancy_path(@pregnancy)
         find('a', text: 'Call Log').click
 

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -48,7 +48,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
     end
 
     it 'should be able to save more than one reached patient call' do
-      click_link 'Dashboard'
+      visit authenticated_root_path
       fill_in 'search', with: 'Susan Everyteen'
       click_button 'Search'
       find("a[href='#call-123-123-1234']").click
@@ -63,27 +63,26 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
   ['Left voicemail', "Couldn't reach patient"].each do |call_status|
     describe "logging #{call_status}", js: true do
       before do
-        if call_status == 'Left voicemail'
-          @link_text = 'I left a voicemail for the patient'
-        elsif call_status == "Couldn't reach patient"
-          @link_text = "I couldn't reach the patient"
-        else
-          raise 'Not a recognized call status'
-        end
-        @timestamp = Time.now
+        @link_text =  if call_status == 'Left voicemail'
+                        'I left a voicemail for the patient'
+                      elsif call_status == "Couldn't reach patient"
+                        "I couldn't reach the patient"
+                      else
+                        raise 'Not a recognized call status'
+                      end
+        @timestamp = Time.zone.now
+        find('a', text: @link_text).click
       end
 
       it "should close the modal when clicking #{call_status}" do
-        click_link @link_text
         assert_equal current_path, authenticated_root_path
         assert has_no_text? 'Call Susan Everyteen now'
         assert has_no_link? @link_text
       end
 
       it "should be visible on the call log after clicking #{call_status}" do
-        click_link @link_text
-        click_link 'Susan Everyteen'
-        click_link 'Call Log'
+        visit edit_pregnancy_path(@pregnancy)
+        find('a', text: 'Call Log').click
 
         within :css, '#call_log' do
           assert has_text? @timestamp.localtime.strftime('%-m/%-d')

--- a/test/integration/note_creation_test.rb
+++ b/test/integration/note_creation_test.rb
@@ -21,7 +21,7 @@ class NoteCreationTest < ActionDispatch::IntegrationTest
     it 'should let you add a new case note' do
       fill_in 'note[full_text]', with: 'Sample new note creation body'
       click_button 'Create Note'
-      assert_text 'Sample new note creation body'
+      assert has_text? 'Sample new note creation body'
     end
   end
 end

--- a/test/integration/note_creation_test.rb
+++ b/test/integration/note_creation_test.rb
@@ -13,13 +13,13 @@ class NoteCreationTest < ActionDispatch::IntegrationTest
     it 'should display a case notes form and current notes' do
       click_link 'Notes'
       within('#notes') do
-        assert_text 'Notes' # confirm notes header is visible
-        page.has_field? 'note[full_text]'
+        assert has_text? 'Notes' # confirm notes header is visible
         assert has_button? 'Create Note'
       end
     end
 
     it 'should let you add a new case note' do
+      assert has_field? 'note[full_text]'
       fill_in 'note[full_text]', with: 'Sample new note creation body'
       click_button 'Create Note'
       assert_text 'Sample new note creation body'

--- a/test/integration/note_creation_test.rb
+++ b/test/integration/note_creation_test.rb
@@ -7,11 +7,11 @@ class NoteCreationTest < ActionDispatch::IntegrationTest
     @patient = create :patient
     @pregnancy = create :pregnancy, patient: @patient
     visit edit_pregnancy_path(@pregnancy)
+    find('a', text: 'Notes').click
   end
 
   describe 'add patient pregnancy notes' do
     it 'should display a case notes form and current notes' do
-      click_link 'Notes'
       within('#notes') do
         assert has_text? 'Notes' # confirm notes header is visible
         assert has_button? 'Create Note'
@@ -19,7 +19,6 @@ class NoteCreationTest < ActionDispatch::IntegrationTest
     end
 
     it 'should let you add a new case note' do
-      assert has_field? 'note[full_text]'
       fill_in 'note[full_text]', with: 'Sample new note creation body'
       click_button 'Create Note'
       assert_text 'Sample new note creation body'

--- a/test/integration/note_creation_test.rb
+++ b/test/integration/note_creation_test.rb
@@ -21,7 +21,9 @@ class NoteCreationTest < ActionDispatch::IntegrationTest
     it 'should let you add a new case note' do
       fill_in 'note[full_text]', with: 'Sample new note creation body'
       click_button 'Create Note'
-      assert has_text? 'Sample new note creation body'
+      within('#notes_log') do
+        assert has_text? 'Sample new note creation body'
+      end
     end
   end
 end

--- a/test/integration/show_pregnancy_information_test.rb
+++ b/test/integration/show_pregnancy_information_test.rb
@@ -10,6 +10,10 @@ class ShowPregnancyInformationTest < ActionDispatch::IntegrationTest
     visit edit_pregnancy_path(@pregnancy)
   end
 
+  after do
+    Capybara.use_default_driver
+  end
+
   describe 'clicking between sections to see information' do
     it 'should show the patient dashboard on open' do
       within :css, '#patient_dashboard' do

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -7,6 +7,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     @pregnancy = create :pregnancy, patient: @patient
     log_in_as @user
     visit edit_pregnancy_path @pregnancy
+    has_text? 'First and last name' # wait until page loads
   end
 
   describe 'changing patient dashboard information' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns out minitest is faster than the webdriver, so tests are randomly failing once in awhile.

Here is a blog post about the general principle about why they're failing - https://nulogy.com/who-we-are/company-blog/articles/sleep-is-for-the-weak/

This pull request makes the following changes:
* Fixes integration tests to wait for elements instead of just pushing ahead, always pushing ahead

It relates to the following issue #s: 
* Bumps #375 