### PR TITLE
Add display_date, display_time, and display_timestamp to time object

### DIFF
--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -2,10 +2,6 @@ class AuditTrail
   include Mongoid::History::Tracker
 
   # convenience methods for clean view display
-  def date_of_edit
-    created_at.getlocal.strftime('%Y-%m-%d')
-  end
-
   def tracked_changes_fields
     modified.keys.map(&:humanize).join('<br>').html_safe
   end

--- a/app/views/pregnancies/_call_log.html.erb
+++ b/app/views/pregnancies/_call_log.html.erb
@@ -11,16 +11,16 @@
 			<tbody>
 				<% pregnancy.recent_calls.each do |call| %>
 					<tr>
-						<td><%= call.created_at.getlocal.strftime("%-m/%-d") %></td>
-						<td><%= call.created_at.getlocal.strftime("%l:%M %P") %></td>
+						<td><%= call.created_at.display_date %></td>
+						<td><%= call.created_at.display_time %></td>
 						<td><%= call.status %></td>
 						<td><%= call.created_by.name %></td>
 					</tr>
 				<% end %>
 				<% pregnancy.old_calls.each do |call| %>
 					<tr class="old-calls hidden">
-						<td><%= call.created_at.getlocal.strftime("%-m/%-d") %></td>
-						<td><%= call.created_at.getlocal.strftime("%l:%M %P") %></td>
+						<td><%= call.created_at.display_date %></td>
+						<td><%= call.created_at.display_time %></td>
 						<td><%= call.status %></td>
 						<td><%= call.created_by.name %></td>
 					</tr>

--- a/app/views/pregnancies/_change_log.html.erb
+++ b/app/views/pregnancies/_change_log.html.erb
@@ -14,7 +14,7 @@
       <tbody>
         <% pregnancy.patient.history_tracks.each do |revision| %>
           <tr>
-            <td><%= revision.date_of_edit %></td>
+            <td><%= revision.created_at.display_date %></td>
             <td><%= revision.tracked_changes_fields %></td>
             <td><%= revision.tracked_changes_from %></td>
             <td><%= revision.tracked_changes_to %></td>

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -14,8 +14,8 @@
 		<tbody>
 			<% pregnancy.notes.order('created_at DESC').each do |note| %>
 				<tr>
-					<th><%= note.created_at.getlocal.strftime("%-m/%-d") %></th>
-					<th><%= note.created_at.getlocal.strftime("%l:%M %P") %></th>
+					<th><%= note.created_at.display_date %></th>
+					<th><%= note.created_at.display_time %></th>
 					<th><%= note.created_by.name %></td>
 				</tr>
 				<tr>

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,0 +1,14 @@
+# Extends time class with convenience methods
+class Time
+  def display_date
+    getlocal.strftime("%Y-%m-%d")
+  end
+
+  def display_time
+    getlocal.strftime("%-l:%M %P")
+  end
+
+  def display_timestamp
+    "#{display_date} #{display_time}"
+  end
+end

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -41,8 +41,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       find('a', text: 'Call Log').click
 
       within :css, '#call_log' do
-        assert has_text? @timestamp.localtime.strftime('%-m/%-d')
-        assert has_text? @timestamp.localtime.strftime('%-l:%M %P')
+        assert has_text? @timestamp.display_date
+        assert has_text? @timestamp.display_time
         assert has_text? 'Reached patient'
         assert has_text? @user.name
       end
@@ -87,8 +87,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         find('a', text: 'Call Log').click
 
         within :css, '#call_log' do
-          assert has_text? @timestamp.localtime.strftime('%-m/%-d')
-          assert has_text? @timestamp.localtime.strftime('%-l:%M %P')
+          assert has_text? @timestamp.display_date
+          assert has_text? @timestamp.display_time
           assert has_text? call_status
           assert has_text? @user.name
         end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Extends our `Time` class by adding convenience display methods to it.

This pull request makes the following changes:
* Adds `#display_date`, which displays a date in the form of 'YYYY-MM-DD'
* Adds `#display_time`, which displays a time in the form of 'HH:MM pm`
* Adds `#display_timestamp`, which displays the date and time using both those methods
* Changes our existing view code to use these methods

It relates to the following issue #s: 
* Fixes #177
