### PR TITLE
Add dropdowns

### DIFF
--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -46,7 +46,7 @@ class PregnanciesController < ApplicationController
       # fields in abortion info
       :procedure_cost,
       # fields in patient info
-      :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income, :household_size, :insurance, :referred_by,
+      :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income, :household_size, :insurance, :referred_by, :special_circumstances,
       # associated
       clinic: [:id, :name, :street_address_1, :street_address_2, :city, :state, :zip],
       patient: [:id, :name, :primary_phone, :secondary_person, :secondary_phone]

--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -6,4 +6,44 @@ module PregnanciesHelper
   def days_options
     (0..6).map { |i| [pluralize(i, 'day'), i] }
   end
+
+  def race_ethnicity_options
+    ['White/Caucasian', 'Black/African-American', 'Hispanic/Latino',
+     'Asian or South Asian', 'Native Hawaiian or Pacific Islander',
+     'Native American', 'Mixed Race/Ethnicity', 'Other']
+  end
+
+  def employment_status_options
+    ['Full-time', 'Part-time', 'Unemployed', 'Odd jobs', 'Student']
+  end
+
+  def insurance_options
+    ['DC Medicaid', 'MD MCHIP', 'MD Medical Assistance for Families (MA4F)',
+     'VA Medicaid/CHIP', 'Other State Medicaid',
+     'Private or employer-sponsored health insurance',
+     'No Insurance', "Don't Know"]
+  end
+
+  def income_options
+    ['Under $9,999 (less than $192/week)', '$10,000-$14,999 ($192-287/week)',
+     '$15,000-19,999 ($288-384/week)', '$20,000-24,999 ($385-480/week)',
+     '$25,000-29,999 ($481-576/week)', '$30,000-34,999 ($577-672/week)',
+     '$35,000-39,000 ($673-768/week)', '$40,000-44,999 ($769-864/week)',
+     '$45,000-49,999 ($865-961/week)', '$50,000-$59,999 ($962-1153/week)',
+     '$60,000-$74,999 ($1154-1441/week)',
+     '$75,000 or more/year ($1442 or more/week)']
+  end
+
+  def referred_by_options
+    ['Clinic', 'Crime Victim Advocacy Center', 'DCAF Website or Social Media',
+     'Domestic Violence Crisis/Intervention Org', 'Family Member', 'Friend',
+     'Google/Web Search', 'Homeless Shelter', 'Legal Clinic', 'NAF', 'NNAF',
+     'Other Abortion Fund', 'Previous Patient', 'School',
+     'Sexual Assault Crisis Org', 'Youth Outreach']
+  end
+
+  def special_circumstances_options
+    ['Domestic Violence', 'Fetal Anomaly', 'Homeless', 'Immigrant', 'Incest',
+     'Maternal Health', 'Other', 'Rape', 'Undocumented/Non-Citizen']
+  end
 end

--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -1,53 +1,54 @@
 module PregnanciesHelper
   def weeks_options
-    (1..30).map { |i| [pluralize(i, 'week'), i] }
+    (1..30).map { |i| [pluralize(i, 'week'), i] }.unshift nil
   end
 
   def days_options
-    (0..6).map { |i| [pluralize(i, 'day'), i] }
+    (0..6).map { |i| [pluralize(i, 'day'), i] }.unshift nil
   end
 
   def race_ethnicity_options
-    ['White/Caucasian', 'Black/African-American', 'Hispanic/Latino',
+    [nil, 'White/Caucasian', 'Black/African-American', 'Hispanic/Latino',
      'Asian or South Asian', 'Native Hawaiian or Pacific Islander',
      'Native American', 'Mixed Race/Ethnicity', 'Other']
   end
 
   def employment_status_options
-    ['Full-time', 'Part-time', 'Unemployed', 'Odd jobs', 'Student']
+    [nil, 'Full-time', 'Part-time', 'Unemployed', 'Odd jobs', 'Student']
   end
 
   def insurance_options
-    ['DC Medicaid', 'MD MCHIP', 'MD Medical Assistance for Families (MA4F)',
-     'VA Medicaid/CHIP', 'Other State Medicaid',
-     'Private or employer-sponsored health insurance',
-     'No Insurance', "Don't Know"]
+    [nil, 'DC Medicaid', 'MD MCHIP',
+     'MD Medical Assistance for Families (MA4F)', 'VA Medicaid/CHIP',
+     'Other state Medicaid', 'Private or employer-sponsored health insurance',
+     'No insurance', "Don't know"]
   end
 
   def income_options
-    ['Under $9,999 (less than $192/week)', '$10,000-$14,999 ($192-287/week)',
-     '$15,000-19,999 ($288-384/week)', '$20,000-24,999 ($385-480/week)',
-     '$25,000-29,999 ($481-576/week)', '$30,000-34,999 ($577-672/week)',
-     '$35,000-39,000 ($673-768/week)', '$40,000-44,999 ($769-864/week)',
-     '$45,000-49,999 ($865-961/week)', '$50,000-$59,999 ($962-1153/week)',
-     '$60,000-$74,999 ($1154-1441/week)',
+    [nil, 'Under $9,999 (less than $192/week)',
+     '$10,000-$14,999 ($192-287/week)', '$15,000-19,999 ($288-384/week)',
+     '$20,000-24,999 ($385-480/week)', '$25,000-29,999 ($481-576/week)',
+     '$30,000-34,999 ($577-672/week)', '$35,000-39,000 ($673-768/week)',
+     '$40,000-44,999 ($769-864/week)', '$45,000-49,999 ($865-961/week)',
+     '$50,000-$59,999 ($962-1153/week)', '$60,000-$74,999 ($1154-1441/week)',
      '$75,000 or more/year ($1442 or more/week)']
   end
 
   def referred_by_options
-    ['Clinic', 'Crime Victim Advocacy Center', 'DCAF Website or Social Media',
-     'Domestic Violence Crisis/Intervention Org', 'Family Member', 'Friend',
-     'Google/Web Search', 'Homeless Shelter', 'Legal Clinic', 'NAF', 'NNAF',
-     'Other Abortion Fund', 'Previous Patient', 'School',
-     'Sexual Assault Crisis Org', 'Youth Outreach']
+    [nil, 'Clinic', 'Crime victim advocacy center',
+     'DCAF website or social media',
+     'Domestic violence crisis/intervention org', 'Family member', 'Friend',
+     'Google/Web search', 'Homeless shelter', 'Legal clinic', 'NAF', 'NNAF',
+     'Other abortion fund', 'Previous patient', 'School',
+     'Sexual assault crisis org', 'Youth outreach']
   end
 
   def special_circumstances_options
-    ['Domestic Violence', 'Fetal Anomaly', 'Homeless', 'Immigrant', 'Incest',
-     'Maternal Health', 'Other', 'Rape', 'Undocumented/Non-Citizen']
+    [nil, 'Domestic violence', 'Fetal anomaly', 'Homeless', 'Immigrant',
+     'Incest', 'Maternal health', 'Other', 'Rape', 'Undocumented/Non-Citizen']
   end
 
   def household_size_options
-    (0..10).map { |i| i }
+    (1..10).map { |i| i }.unshift nil
   end
 end

--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -1,10 +1,10 @@
 module PregnanciesHelper
   def weeks_options
-    (1..30).map { |i| [pluralize(i, 'week'), i] }.unshift nil
+    (1..30).map { |i| [pluralize(i, 'week'), i] }.unshift [nil, nil]
   end
 
   def days_options
-    (0..6).map { |i| [pluralize(i, 'day'), i] }.unshift nil
+    (0..6).map { |i| [pluralize(i, 'day'), i] }.unshift [nil, nil]
   end
 
   def race_ethnicity_options
@@ -49,6 +49,6 @@ module PregnanciesHelper
   end
 
   def household_size_options
-    (1..10).map { |i| i }.unshift nil
+    (1..10).map { |i| i }.unshift [nil, nil]
   end
 end

--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -46,4 +46,8 @@ module PregnanciesHelper
     ['Domestic Violence', 'Fetal Anomaly', 'Homeless', 'Immigrant', 'Incest',
      'Maternal Health', 'Other', 'Rape', 'Undocumented/Non-Citizen']
   end
+
+  def household_size_options
+    (0..10).map { |i| i }
+  end
 end

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -38,7 +38,7 @@ class Pregnancy
   field :employment_status, type: String
   field :household_size, type: Integer
   field :insurance, type: String
-  field :income, type: Integer
+  field :income, type: String
   field :referred_by, type: String
   field :special_circumstances, type: String # ennumeration
 

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -5,17 +5,21 @@
         <h2>Patient information</h2>
       </div>
     </div>
+
     <div class="row">
       <div class="info-form-left col-sm-6">
         <%= f.fields_for pregnancy.patient do |p| %>
-        <%= p.text_field :secondary_person, autocomplete: 'off' %>
-        <%= p.text_field :secondary_phone, autocomplete: 'off' %>
+          <%= p.text_field :secondary_person, autocomplete: 'off' %>
+          <%= p.text_field :secondary_phone, autocomplete: 'off' %>
         <% end %>
+  
         <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
-        <%= f.select :race_ethnicity, options_for_select(
-        ['', 'Caucasian', 'African American',
-          'Asian/Pacific Islander', 'Hispanic'],
-          pregnancy.race_ethnicity), label: 'Race / Ethnicity', autocomplete: 'off' %>
+        <%= f.select :race_ethnicity, 
+                     options_for_select(race_ethnicity_options,
+                                        pregnancy.race_ethnicity),
+                                        label: 'Race / Ethnicity', 
+                                        autocomplete: 'off' %>
+
         <div class="row">
           <div class="col-sm-8">
             <%= f.text_field :city, label: 'City', autocomplete: 'off' %>
@@ -24,22 +28,27 @@
             <%= f.text_field :state, label: 'State', autocomplete: 'off' %>
           </div>
         </div>
+
         <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
       </div>
 
       <div class="info-form-right col-sm-6">
-        <%= f.select :employment_status, options_for_select(
-        ['Full-time', 'Part-time', 'Unemployed'],
-        pregnancy.employment_status), label: 'Employment status' %>
-        <%= f.select :income, options_for_select(
-        { 'Range 1' => 1, 'Range 2' => 2 }, pregnancy.income),
-        label: 'Income' %>
-        <%= f.select :household_size, options_for_select(
-        { 'Size 1' => 1, 'Size 2' => 2 }, pregnancy.household_size),
-        label: 'People in household' %>
-        <%= f.select :insurance, options_for_select(
-        ['option 1', 'option 2'], pregnancy.insurance),
-        label: 'Patient insurance' %>
+        <%= f.select :employment_status, 
+                     options_for_select(employment_status_options,
+                                        pregnancy.employment_status),
+                                        label: 'Employment status' %>
+        <%= f.select :income, 
+                     options_for_select(income_options,
+                                        pregnancy.income),
+                                        label: 'Income' %>
+        <%= f.select :household_size, 
+                      options_for_select(household_size_options,
+                                         pregnancy.household_size),
+                                         label: 'People in household' %>
+        <%= f.select :insurance, 
+                     options_for_select(insurance_options,
+                                        pregnancy.insurance),
+                                        label: 'Patient insurance' %>
         <%= f.text_field :referred_by, label: 'Referred by', autocomplete: 'off' %>
         <!-- special_circumstances checkbox-->
         <h5>PLACEHOLDER: Special Circumstances</h5>

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -36,11 +36,11 @@
         <%= f.select :employment_status, 
                      options_for_select(employment_status_options,
                                         pregnancy.employment_status),
-                                        label: 'Employment status' %>
+                                        autocomplete: 'off' %>
         <%= f.select :income, 
                      options_for_select(income_options,
                                         pregnancy.income),
-                                        label: 'Income' %>
+                                        autocomplete: 'off' %>
         <%= f.select :household_size, 
                       options_for_select(household_size_options,
                                          pregnancy.household_size),
@@ -49,9 +49,14 @@
                      options_for_select(insurance_options,
                                         pregnancy.insurance),
                                         label: 'Patient insurance' %>
-        <%= f.text_field :referred_by, label: 'Referred by', autocomplete: 'off' %>
-        <!-- special_circumstances checkbox-->
-        <h5>PLACEHOLDER: Special Circumstances</h5>
+        <%= f.select :referred_by,
+                     options_for_select(referred_by_options,
+                                        pregnancy.referred_by),
+                                        autocomplete: 'off' %>
+        <%= f.select :special_circumstances,
+                     options_for_select(special_circumstances_options,
+                                        pregnancy.special_circumstances),
+                                        autocomplete: 'off' %>
       </div>
     </div>
   </div>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+branches:
+  - master
+threshold: "1%"

--- a/test/helpers/pregnancies_helper_test.rb
+++ b/test/helpers/pregnancies_helper_test.rb
@@ -3,26 +3,37 @@ require 'test_helper'
 class PregnanciesHelperTest < ActionView::TestCase
   describe 'weeks_options' do
     it 'should pluralize properly' do
-      assert_equal '1 week', weeks_options.first[0]
-      assert_equal '2 weeks', weeks_options.second[0]
+      assert_equal '1 week', weeks_options.second[0]
+      assert_equal '2 weeks', weeks_options.third[0]
       assert_equal 1, weeks_options.select { |x| /week$/.match x[0] }.count
     end
 
     it 'should have 30 entries' do
-      assert_equal 30, weeks_options.count
+      assert_equal 31, weeks_options.count
     end
   end
 
   describe 'days_options' do
     it 'should pluralize properly' do
-      assert_equal '0 days', days_options.first[0]
-      assert_equal '1 day', days_options.second[0]
-      assert_equal '2 days', days_options.third[0]
+      assert_equal '0 days', days_options.second[0]
+      assert_equal '1 day', days_options.third[0]
+      assert_equal '2 days', days_options.fourth[0]
       assert_equal 1, days_options.select { |x| /day$/.match x[0] }.count
     end
 
     it 'should have 7 entries' do
-      assert_equal 7, days_options.count
+      assert_equal 8, days_options.count
+    end
+  end
+
+  %w(race_ethnicity employment_status insurance income referred_by
+     special_circumstances household_size).each do |array|
+    describe "#{array}_options" do
+      it "should be a usable array - #{array}_options" do
+        options_array = send("#{array}_options".to_sym)
+        assert options_array.class == Array
+        assert options_array.count > 1
+      end
     end
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -66,7 +66,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
       find('#pregnancy_employment_status').select 'Part-time'
       find('#pregnancy_income').select '$30,000-34,999 ($577-672/week)'
-      find('#pregnancy_people_in_household').select '1'
+      find('#pregnancy_household_size').select '1'
       find('#pregnancy_patient_insurance').select 'Other state medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
       find('#pregnancy_special_circumstances').select 'Other'
@@ -89,11 +89,10 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
         assert_equal find('#pregnancy_employment_status').value, 'Part-time'
         assert_equal find('#pregnancy_income').value '$30,000-34,999 ($577-672/week)'
-        assert_equal find('#pregnancy_people_in_household').value '1'
+        assert_equal find('#pregnancy_household_size').value '1'
         assert_equal find('#pregnancy_patient_insurance').value 'Other state medicaid'
         assert_equal find('#pregnancy_referred_by').value 'Other abortion fund'
         assert_equal find('#pregnancy_special_circumstances').value 'Other'
-        # TK Special circumstances
       end
     end
   end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -67,10 +67,9 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_employment_status').select 'Part-time'
       find('#pregnancy_income').select '$30,000-34,999 ($577-672/week)'
       find('#pregnancy_household_size').select '1'
-      find('#pregnancy_patient_insurance').select 'Other state medicaid'
+      find('#pregnancy_insurance').select 'Other state Medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
       find('#pregnancy_special_circumstances').select 'Other'
-      fill_in 'Referred by', with: 'Friend'
 
       click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
@@ -82,17 +81,17 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'Secondary person', with: 'Susie Everyteen Sr'
         assert has_field? 'Secondary phone', with: '123-666-7777'
         assert has_field? 'Age', with: '24'
-        assert_equal find('#pregnancy_race_ethnicity').value, 'White/Caucasian'
+        assert_equal 'White/Caucasian', find('#pregnancy_race_ethnicity').value
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'ZIP', with: '90210'
 
-        assert_equal find('#pregnancy_employment_status').value, 'Part-time'
-        assert_equal find('#pregnancy_income').value '$30,000-34,999 ($577-672/week)'
-        assert_equal find('#pregnancy_household_size').value '1'
-        assert_equal find('#pregnancy_patient_insurance').value 'Other state medicaid'
-        assert_equal find('#pregnancy_referred_by').value 'Other abortion fund'
-        assert_equal find('#pregnancy_special_circumstances').value 'Other'
+        assert_equal 'Part-time', find('#pregnancy_employment_status').value
+        assert_equal '$30,000-34,999 ($577-672/week)', find('#pregnancy_income').value
+        assert_equal '1', find('#pregnancy_household_size').value
+        assert_equal 'Other state Medicaid', find('#pregnancy_insurance').value
+        assert_equal 'Other abortion fund', find('#pregnancy_referred_by').value
+        assert_equal 'Other', find('#pregnancy_special_circumstances').value
       end
     end
   end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -59,17 +59,18 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       fill_in 'Secondary person', with: 'Susie Everyteen Sr'
       fill_in 'Secondary phone', with: '123-666-7777'
       fill_in 'Age', with: '24'
-      find('#pregnancy_race_ethnicity').select 'Caucasian'
+      find('#pregnancy_race_ethnicity').select 'White/Caucasian'
       fill_in 'City', with: 'Washington'
       fill_in 'State', with: 'DC'
       fill_in 'ZIP', with: '90210'
 
       find('#pregnancy_employment_status').select 'Part-time'
-      # find('#pregnancy_income').select 'Full-time'
-      # find('#pregnancy_people_in_household').select 'Full-time'
-      # find('#pregnancy_patient_insurance').select 'Full-time'
+      find('#pregnancy_income').select '$30,000-34,999 ($577-672/week)'
+      find('#pregnancy_people_in_household').select '1'
+      find('#pregnancy_patient_insurance').select 'Other state medicaid'
+      find('#pregnancy_referred_by').select 'Other abortion fund'
+      find('#pregnancy_special_circumstances').select 'Other'
       fill_in 'Referred by', with: 'Friend'
-      # TK Special circumstances
 
       click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
@@ -81,16 +82,17 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'Secondary person', with: 'Susie Everyteen Sr'
         assert has_field? 'Secondary phone', with: '123-666-7777'
         assert has_field? 'Age', with: '24'
-        assert_equal find('#pregnancy_race_ethnicity').value, 'Caucasian'
+        assert_equal find('#pregnancy_race_ethnicity').value, 'White/Caucasian'
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'ZIP', with: '90210'
 
         assert_equal find('#pregnancy_employment_status').value, 'Part-time'
-        # assert_equal find('#pregnancy_income').value, 'Full-time'
-        # assert_equal find('#pregnancy_people_in_household').value, 'Full-time'
-        # assert_equal find('#pregnancy_patient_insurance').value, 'Full-time'
-        assert has_field? 'Referred by', with: 'Friend'
+        assert_equal find('#pregnancy_income').value '$30,000-34,999 ($577-672/week)'
+        assert_equal find('#pregnancy_people_in_household').value '1'
+        assert_equal find('#pregnancy_patient_insurance').value 'Other state medicaid'
+        assert_equal find('#pregnancy_referred_by').value 'Other abortion fund'
+        assert_equal find('#pregnancy_special_circumstances').value 'Other'
         # TK Special circumstances
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Creates a slew of view helpers for structured pregnancy information using patterns established by @charleshuang80 .

Keeping them as strings on the model for now for reasons of portability. If we decide we'd rather have as model enums, should be easy enough to switch over. 

This pull request makes the following changes:
* Alters (attribute)_options methods and works them into the patient_information view
* Adjusts tests to match

It relates to the following issue #s: 
* Fixes #200
