### PR TITLE
Add bootstrap-toggle to new pregnancy partial

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .
+//= require_tree ../../../vendor/assets/javascripts/.
 
 $(document).ready(function(){
 
@@ -44,4 +45,7 @@ $(document).ready(function(){
 		$('.pledge_modal_screen3').hide();		
 	})
 
+  $('[data-toggle="toggle"]').bootstrapToggle();
 })
+
+

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,5 +1,6 @@
 /*
  *= require rails_bootstrap_forms
+ *= require_tree ../../../vendor/assets/stylesheets/.
  *= require_tree .
 */
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -20,3 +20,7 @@
     width: 350px;
   }
 }
+
+.bootstrap_toggle_spacing .checkbox {
+  margin-top: 0px;
+}

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -27,7 +27,9 @@
 
   <div class="col-sm-2">
     <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
-    <%= f.check_box :voicemail_ok, label: 'Yes' %> <!-- TODO add bootstrap toggle -->
+      <div class='bootstrap_toggle_spacing'>
+        <%= f.check_box :voicemail_ok, data: { toggle: 'toggle', on: 'Yes', off: 'No' }, label: '', checked: 'checked' %>
+      </div>
     <% end %>
   </div>
 
@@ -38,3 +40,5 @@
     <% end %>
   </div>
 <% end %>
+
+<script>$('[data-toggle="toggle"]').bootstrapToggle();</script>

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -20,6 +20,12 @@
                                         label: 'Race / Ethnicity', 
                                         autocomplete: 'off' %>
 
+        <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
+          <!-- <div class='bootstrap_toggle_spacing'> -->
+            <%= f.check_box :voicemail_ok, label: '' %>
+          <!-- </div> -->
+        <% end %>
+
         <div class="row">
           <div class="col-sm-8">
             <%= f.text_field :city, label: 'City', autocomplete: 'off' %>
@@ -61,5 +67,4 @@
     </div>
   </div>
 </section>
-
 

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -23,6 +23,7 @@
         <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
           <!-- <div class='bootstrap_toggle_spacing'> -->
             <%= f.check_box :voicemail_ok, label: '' %>
+            <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
           <!-- </div> -->
         <% end %>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

@sco-bo I took yr PR and ran with a little bit. Couldn't quite get it to work on the pregnancy edit view (might be a bootstrap_forms gem issue?) so I stubbed it for the time being. Thanks for getting this going, my dude! Want to take a look at this and confirm that it makes sense and stuff?

<img width="1152" alt="screen shot 2016-06-26 at 2 25 59 pm" src="https://cloud.githubusercontent.com/assets/3866868/16363988/344f26d8-3baa-11e6-8e25-e4c032530608.png">

<img width="801" alt="screen shot 2016-06-26 at 2 28 23 pm" src="https://cloud.githubusercontent.com/assets/3866868/16363991/41da58a4-3baa-11e6-883f-240e00831265.png">

This pull request makes the following changes:
* Finishes off adding pretty toggle switch to new pregnancy form
* Adds plain old boring checkbox to pregnancy edit view

It relates to the following issue #s: 
* Half-fixes #365 
