### PR TITLE
Prevent host header injection

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,14 +57,16 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # Prevent host header injection
+  config.action_controller.default_url_options = { host: (ENV['SITE_URL'] || 'localhost') }
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = (ENV['SITE_URL'] || 'localhost')
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.default_url_options = { :host => 'casemanagerdemo.herokuapp.com' }
+  config.action_mailer.default_url_options = { :host => (ENV['SITE_URL'] || 'localhost') }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Small fix to prevent header screwin' with.

This pull request makes the following changes:
* some production config edits
* adding an env var

It relates to the following issue #s: 
* Fixes #414
* Bumps #387 (makes the config change; doesn't fix the heroku-side settings) 

