### PR TITLE
bump Ruby version / Haunt Dockerfile with PhantomJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN apt-get install -y libxml2-dev libxslt1-dev
 RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
 
 # for a JS runtime
-RUN apt-get install -y nodejs
+RUN apt-get install -y nodejs && ln -s `which nodejs` /usr/bin/node
+RUN apt-get install -y npm
+
+# for phantomjs
+RUN npm install -g phantomjs-prebuilt
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.4'
+ruby '2.3.1'
 
 gem 'rails', '~> 4.2.6'
 gem 'sass-rails', '~> 5.0'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.2.4
+    version: 2.3.1
 
 deployment:
   staging:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

SpooooOOOOOOooooky

**Note: To not futz with Docker builds and ruby version issues too badly, we're going to bump the ruby version to the latest secure version, 2.3.1.**

This pull request makes the following changes:
* Bumps ruby to 2.3.1
* Haunts Dockerfile
* Adjusts a few other files to reflect new ruby version

It relates to the following issue #s: 
* Fixes #312

