### PR TITLE
Turn on devise paranoid mode

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -72,7 +72,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -30,7 +30,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
     it 'should errror if email does not exist' do
       fill_in 'Email', with: 'not_a_real_email@gmail.com'
       click_button 'Send me password reset instructions'
-      assert_text 'Email not found'
+      assert_text 'If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes'
       assert_routing new_user_password_path, controller: 'devise/passwords', action: 'new'
       assert_equal Devise.mailer.deliveries.count, 0
     end
@@ -38,7 +38,7 @@ class PasswordResetTest < ActionDispatch::IntegrationTest
     it 'should send a password reset if email does exist' do
       fill_in 'Email', with: @user.email
       click_button 'Send me password reset instructions'
-      assert_text 'You will receive an email with instructions on how to reset your password in a few minutes.'
+      assert_text 'If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes'
       assert_routing new_user_session_path, controller: 'devise/sessions', action: 'new'
 
       # confirm email got sent


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns on devise's `paranoid_mode` to prevent enumeration sketchiness with the password reset form.

cc @mccabe615

This pull request makes the following changes:
* literally just uncomments a line in the devise initializer

![screen shot 2016-06-28 at 10 23 03 pm](https://cloud.githubusercontent.com/assets/3866868/16438568/f59d68ce-3d7e-11e6-87cb-edf3fa2dd2a1.png)

It relates to the following issue #s: 
* Fixes #418 
* Fixes #380 
