### PR TITLE
Change special circumstances to a text field for now

### DIFF
--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -60,10 +60,7 @@
                      options_for_select(referred_by_options,
                                         pregnancy.referred_by),
                                         autocomplete: 'off' %>
-        <%= f.select :special_circumstances,
-                     options_for_select(special_circumstances_options,
-                                        pregnancy.special_circumstances),
-                                        autocomplete: 'off' %>
+        <%= f.text_field :special_circumstances, autocomplete: 'Off' %>
       </div>
     </div>
   </div>

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -69,7 +69,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_household_size').select '1'
       find('#pregnancy_insurance').select 'Other state Medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
-      find('#pregnancy_special_circumstances').select 'Other'
+      fill_in 'Special circumstances', with: 'Stuff'
 
       click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
@@ -91,7 +91,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert_equal '1', find('#pregnancy_household_size').value
         assert_equal 'Other state Medicaid', find('#pregnancy_insurance').value
         assert_equal 'Other abortion fund', find('#pregnancy_referred_by').value
-        assert_equal 'Other', find('#pregnancy_special_circumstances').value
+        assert_equal 'Stuff', find('#pregnancy_special_circumstances').value
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns the `special_circumstances` select into a text field, so we can stub before the test run.

This pull request makes the following changes:
* does what it says on the label

It relates to the following issue #s: 
* deploy-bumps #434 
