### PR TITLE
Ajaxify pregnancy edit view and note creation

### DIFF
--- a/app/assets/javascripts/pregnancies.coffee
+++ b/app/assets/javascripts/pregnancies.coffee
@@ -2,7 +2,11 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
+
 $(document).on "click", "#toggle-call-log", ->
   $(".old-calls").toggleClass("hidden")
   html = if $(".old-calls").hasClass("hidden") then "View all calls" else "Limit list"
   $("#toggle-call-log").html(html)
+
+$(document).on "change", ".edit_pregnancy", ->
+  $(this).submit()

--- a/app/assets/javascripts/pregnancies.coffee
+++ b/app/assets/javascripts/pregnancies.coffee
@@ -2,7 +2,6 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-
 $(document).on "click", "#toggle-call-log", ->
   $(".old-calls").toggleClass("hidden")
   html = if $(".old-calls").hasClass("hidden") then "View all calls" else "Limit list"

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -5,10 +5,13 @@ class NotesController < ApplicationController
   def create
     @note = @pregnancy.notes.new note_params
     @note.created_by = current_user
-    @note.save!
-    @notes = @pregnancy.reload.notes.order_by 'created_at desc'
-    respond_to do |format|
-      format.js
+    if @note.save
+      @notes = @pregnancy.reload.notes.order_by 'created_at desc'
+      respond_to do |format|
+        format.js
+      end
+    else
+      head :bad_request
     end
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,6 +6,7 @@ class NotesController < ApplicationController
     @note = @pregnancy.notes.new note_params
     @note.created_by = current_user
     @note.save!
+    @notes = @pregnancy.reload.notes.order_by 'created_at desc'
     respond_to do |format|
       format.js
     end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -5,13 +5,9 @@ class NotesController < ApplicationController
   def create
     @note = @pregnancy.notes.new note_params
     @note.created_by = current_user
-    if @note.save
-      redirect_to edit_pregnancy_path(@pregnancy),
-                  flash: { notice: 'Saved new note for ' \
-                                   "#{@pregnancy.patient.name}!" }
-    else
-      flash[:alert] = 'Note failed to save! Please submit the note again.'
-      redirect_to edit_pregnancy_path @pregnancy
+    @note.save!
+    respond_to do |format|
+      format.js
     end
   end
 

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -15,20 +15,15 @@ class PregnanciesController < ApplicationController
   end
 
   def edit
-    @note = Note.new
+    @note = @pregnancy.notes.new
   end
 
   def update
     if @pregnancy.update_attributes pregnancy_params
-      redirect_to edit_pregnancy_path(@pregnancy),
-                  flash: { notice: 'Saved patient info!' }
+      head :success
     else
       head :bad_request
-      # redirect_to edit_pregnancy_path(@pregnancy),
-      #             flash: { alert: 'Error saving info!' }
     end
-
-    # TODO: respond_to format.js eventually
   end
 
   private

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -19,8 +19,8 @@ class PregnanciesController < ApplicationController
   end
 
   def update
-    if @pregnancy.update pregnancy_params
-      head :success
+    if @pregnancy.update_attributes pregnancy_params
+      head :ok
     else
       head :bad_request
     end

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -19,7 +19,7 @@ class PregnanciesController < ApplicationController
   end
 
   def update
-    if @pregnancy.update_attributes pregnancy_params
+    if @pregnancy.update pregnancy_params
       head :success
     else
       head :bad_request

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -53,7 +53,7 @@ class Pregnancy
   validates :initial_call_date,
             :created_by,
             presence: true
-  validates_associated :patient, on: :create
+  validates_associated :patient
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/app/views/notes/_notes_table.html.erb
+++ b/app/views/notes/_notes_table.html.erb
@@ -1,0 +1,16 @@
+<table class="table border-side" id='notes_log'>
+  <tbody>    
+    <% notes.each do |note| %>
+      <% unless note.new_record? %>
+        <tr>
+          <th><%= note.created_at.display_date %></th>
+          <th><%= note.created_at.display_time %></th>
+          <th><%= note.created_by.name %></td>
+        </tr>
+        <tr>
+          <td><%= note.full_text %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  <tbody>
+</table>

--- a/app/views/notes/create.js.erb
+++ b/app/views/notes/create.js.erb
@@ -1,1 +1,2 @@
+$('#note_full_text').val('');
 $('#notes_log').empty().append('<%= escape_javascript(render partial: "notes/notes_table", locals: { notes: @notes } ) %>');

--- a/app/views/notes/create.js.erb
+++ b/app/views/notes/create.js.erb
@@ -1,1 +1,1 @@
-$('#notes_log').prepend('Placeholder for now');
+$('#notes_log').empty().append('<%= escape_javascript(render partial: "notes/notes_table", locals: { notes: @notes } ) %>');

--- a/app/views/notes/create.js.erb
+++ b/app/views/notes/create.js.erb
@@ -1,1 +1,1 @@
-$('#notes_content').prepend('Placeholder for now');
+$('#notes_log').prepend('Placeholder for now');

--- a/app/views/pregnancies/_abortion_information.html.erb
+++ b/app/views/pregnancies/_abortion_information.html.erb
@@ -1,37 +1,39 @@
 <section id="abortion_information" class="abortion-info tab-pane active">
-  <div class="col-sm-12">
-    <div class="row">
-      <div class="col-sm-12">
-        <h2>Abortion information</h2>
+  <%= bootstrap_form_for @pregnancy, html: { id: 'abortion-information-form' }, remote: true do |f| %>
+    <div class="col-sm-12">
+      <div class="row">
+        <div class="col-sm-12">
+          <h2>Abortion information</h2>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <div class="info-form-left">
-          <%= f.fields_for (pregnancy.clinic || pregnancy.build_clinic) do |cl| %>
-          <h4>Clinic details</h4>
-          <%= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
-          <%= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
-          <%= cl.text_field :street_address_2, label: 'Street address 2:', autocomplete: 'off' %>
-          <div class="row">
-            <div class="col-sm-8">
-              <%= cl.text_field :city, label: 'City:', autocomplete: 'off' %>
-            </div>
-            <div class="col-sm-4">
-              <%= cl.text_field :state, label: 'State:', autocomplete: 'off' %>
-            </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="info-form-left">
+            <%= f.fields_for (pregnancy.clinic || pregnancy.build_clinic) do |cl| %>
+              <h4>Clinic details</h4>
+              <%= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
+              <%= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
+              <%= cl.text_field :street_address_2, label: 'Street address 2:', autocomplete: 'off' %>
+              <div class="row">
+                <div class="col-sm-8">
+                  <%= cl.text_field :city, label: 'City:', autocomplete: 'off' %>
+                </div>
+                <div class="col-sm-4">
+                  <%= cl.text_field :state, label: 'State:', autocomplete: 'off' %>
+                </div>
+              </div>
+              <%= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
+            <% end %>
           </div>
-          <%= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
-          <% end %>
         </div>
-      </div>
-      <div class="col-sm-6">
-        <div class="info-form-right">
-          <h4>Cost details</h4>
-          <%= f.text_field :procedure_cost, label: 'Abortion Cost:', autocomplete: 'off' %>
-          <h5>PLACEHOLDER: Funding Sources</h5>
+        <div class="col-sm-6">
+          <div class="info-form-right">
+            <h4>Cost details</h4>
+            <%= f.text_field :procedure_cost, label: 'Abortion Cost:', autocomplete: 'off' %>
+            <h5>PLACEHOLDER: Funding Sources</h5>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </section>

--- a/app/views/pregnancies/_menu.html.erb
+++ b/app/views/pregnancies/_menu.html.erb
@@ -11,7 +11,7 @@
   </ul>
   <div class="row">
     <div class="col-sm-10">
-      <%= f.submit 'TEMP: SAVE INFORMATION', class: 'btn btn-primary btn-block' %>
+      <%#= f.submit 'TEMP: SAVE INFORMATION', class: 'btn btn-primary btn-block' %>
       <a class="btn btn-primary btn-lg submit-btn btn-block" data-toggle="modal"  data-target=".pledge_modal">Submit pledge</a>
     </div>
   </div>

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -11,20 +11,5 @@
 		</div>
 	<% end %>
 
-	<table class="table border-side" id='notes_log'>
-		<tbody>
-      <%= pregnancy.notes.order('created_at DESC').each do |n| %>
-      	<% unless n.new_record? %>
-	        <tr>
-	          <th><%= n.created_at %></th>
-	          <th><%= n.created_at %></th>
-	          <th><%= n.created_by.name %></td>
-	        </tr>
-	        <tr>
-	          <td><%= n.full_text %></td>
-	        </tr>
-	      <% end %>
-      <% end %>
-		<tbody>
-	</table>
+	<%= render partial: 'notes/notes_table', locals: { notes: pregnancy.notes.order_by('created_at desc') } %>
 </section>

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -1,27 +1,30 @@
 <section id="notes" class="notes tab-pane">
-	<div class="col-sm-12 margin-bottom">
-		<div class="row">
-			<div class="info-form-left col-sm-12">
-				<h2>Notes</h2>
-				<%= bootstrap_form_for [pregnancy, note] do |f| %>
-					<%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
-					<%= f.submit class: "btn btn-primary"  %>
-				<% end %>
+	<%= bootstrap_form_for @note, html: { id: 'notes-form' }, remote: true do |f| %>  
+		<div class="col-sm-12 margin-bottom">
+			<div class="row">
+				<div class="info-form-left col-sm-12">
+					<h2>Notes</h2>
+	        <%# f.fields_for pregnancy.notes.new do |n| %>
+	          <%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
+	          <%= f.submit class: "btn btn-primary"  %>
+					<%# end %>
+				</div>
 			</div>
 		</div>
-	</div>
+	<% end %>
+
 	<table class="table border-side" id='notes_log'>
 		<tbody>
-			<% pregnancy.notes.order('created_at DESC').each do |note| %>
-				<tr>
-					<th><%= note.created_at.display_date %></th>
-					<th><%= note.created_at.display_time %></th>
-					<th><%= note.created_by.name %></td>
-				</tr>
-				<tr>
-					<td><%= note.full_text %></td>
-				</tr>
-			<% end %>
+      <%= @pregnancy.notes.order('created_at DESC').each do |note| %>
+        <tr>
+          <th><%#= note.created_at.display_date %></th>
+          <th><%#= note.created_at.display_time %></th>
+          <th><%#= note.created_by.name %></td>
+        </tr>
+        <tr>
+          <td><%#= note.full_text %></td>
+        </tr>
+      <% end %>
 		<tbody>
 	</table>
 </section>

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -1,13 +1,11 @@
 <section id="notes" class="notes tab-pane">
-	<%= bootstrap_form_for @note, html: { id: 'notes-form' }, remote: true do |f| %>  
+	<%= bootstrap_form_for [pregnancy, note], html: { id: 'notes-form' }, remote: true do |f| %>  
 		<div class="col-sm-12 margin-bottom">
 			<div class="row">
 				<div class="info-form-left col-sm-12">
 					<h2>Notes</h2>
-	        <%# f.fields_for pregnancy.notes.new do |n| %>
-	          <%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
-	          <%= f.submit class: "btn btn-primary"  %>
-					<%# end %>
+          <%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
+          <%= f.submit class: "btn btn-primary"  %>
 				</div>
 			</div>
 		</div>
@@ -15,15 +13,17 @@
 
 	<table class="table border-side" id='notes_log'>
 		<tbody>
-      <%= @pregnancy.notes.order('created_at DESC').each do |note| %>
-        <tr>
-          <th><%#= note.created_at.display_date %></th>
-          <th><%#= note.created_at.display_time %></th>
-          <th><%#= note.created_by.name %></td>
-        </tr>
-        <tr>
-          <td><%#= note.full_text %></td>
-        </tr>
+      <%= pregnancy.notes.order('created_at DESC').each do |n| %>
+      	<% unless n.new_record? %>
+	        <tr>
+	          <th><%= n.created_at %></th>
+	          <th><%= n.created_at %></th>
+	          <th><%= n.created_by.name %></td>
+	        </tr>
+	        <tr>
+	          <td><%= n.full_text %></td>
+	        </tr>
+	      <% end %>
       <% end %>
 		<tbody>
 	</table>

--- a/app/views/pregnancies/_patient_dashboard.html.erb
+++ b/app/views/pregnancies/_patient_dashboard.html.erb
@@ -1,26 +1,28 @@
-<div class="col-sm-4" >
-  <%= f.fields_for pregnancy.patient do |p| %>
-    <%= p.text_field :name, label: 'First and last name', autocomplete: 'off' %>
-    <%= p.text_field :primary_phone, label: 'Phone number', autocomplete: 'off' %>
-  <% end %>
-</div>
+<%= bootstrap_form_for @pregnancy, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
+  <div class="col-sm-4" >
+    <%= f.fields_for pregnancy.patient do |p| %>
+      <%= p.text_field :name, label: 'First and last name', autocomplete: 'off' %>
+      <%= p.text_field :primary_phone, label: 'Phone number', autocomplete: 'off' %>
+    <% end %>
+  </div>
 
-<div class="col-sm-4">
-  <div class="row">
-    <div class="col-sm-6">
-      <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, pregnancy.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off', help: "Currently: #{pregnancy.last_menstrual_period_display_short}" %>
+  <div class="col-sm-4">
+    <div class="row">
+      <div class="col-sm-6">
+        <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, pregnancy.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off', help: "Currently: #{pregnancy.last_menstrual_period_display_short}" %>
+      </div>
+      <div class="col-sm-6 hide-label">
+        <%= f.select :last_menstrual_period_days, options_for_select(days_options, pregnancy.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{pregnancy.initial_call_date}" %>
+      </div>
     </div>
-    <div class="col-sm-6 hide-label">
-      <%= f.select :last_menstrual_period_days, options_for_select(days_options, pregnancy.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{pregnancy.initial_call_date}" %>
+    <div class="row">
+      <div class="col-sm-12">
+        <p><strong>Status:</strong> <%= pregnancy.status %></p>
+      </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-sm-12">
-      <p><strong>Status:</strong> <%= pregnancy.status %></p>
-    </div>
-  </div>
-</div>
 
-<div class="col-sm-4">
-  <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', help: "Approx gestation at appt: STUB" %>
-</div>
+  <div class="col-sm-4">
+    <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', help: "Approx gestation at appt: STUB" %>
+  </div>
+<% end %>

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -1,68 +1,69 @@
 <section id="patient_information" class="abortion-info tab-pane">
-  <div class="col-sm-12">
-    <div class="row">
-      <div class="col-sm-12">
-        <h2>Patient information</h2>
+  <%= bootstrap_form_for @pregnancy, html: { id: 'patient_information_form' }, remote: true do |f| %>
+    <div class="col-sm-12">
+      <div class="row">
+        <div class="col-sm-12">
+          <h2>Patient information</h2>
+        </div>
       </div>
-    </div>
 
-    <div class="row">
-      <div class="info-form-left col-sm-6">
-        <%= f.fields_for pregnancy.patient do |p| %>
-          <%= p.text_field :secondary_person, autocomplete: 'off' %>
-          <%= p.text_field :secondary_phone, autocomplete: 'off' %>
-        <% end %>
-  
-        <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
-        <%= f.select :race_ethnicity, 
-                     options_for_select(race_ethnicity_options,
-                                        pregnancy.race_ethnicity),
-                                        label: 'Race / Ethnicity', 
-                                        autocomplete: 'off' %>
+      <div class="row">
+        <div class="info-form-left col-sm-6">
+          <%= f.fields_for pregnancy.patient do |p| %>
+            <%= p.text_field :secondary_person, autocomplete: 'off' %>
+            <%= p.text_field :secondary_phone, autocomplete: 'off' %>
+          <% end %>
+    
+          <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
+          <%= f.select :race_ethnicity, 
+                       options_for_select(race_ethnicity_options,
+                                          pregnancy.race_ethnicity),
+                                          label: 'Race / Ethnicity', 
+                                          autocomplete: 'off' %>
 
-        <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
-          <!-- <div class='bootstrap_toggle_spacing'> -->
-            <%= f.check_box :voicemail_ok, label: '' %>
-            <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
-          <!-- </div> -->
-        <% end %>
+          <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
+            <!-- <div class='bootstrap_toggle_spacing'> -->
+              <%= f.check_box :voicemail_ok, label: '' %>
+              <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
+            <!-- </div> -->
+          <% end %>
 
-        <div class="row">
-          <div class="col-sm-8">
-            <%= f.text_field :city, label: 'City', autocomplete: 'off' %>
+          <div class="row">
+            <div class="col-sm-8">
+              <%= f.text_field :city, label: 'City', autocomplete: 'off' %>
+            </div>
+            <div class="col-sm-4">
+              <%= f.text_field :state, label: 'State', autocomplete: 'off' %>
+            </div>
           </div>
-          <div class="col-sm-4">
-            <%= f.text_field :state, label: 'State', autocomplete: 'off' %>
-          </div>
+
+          <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
         </div>
 
-        <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
-      </div>
-
-      <div class="info-form-right col-sm-6">
-        <%= f.select :employment_status, 
-                     options_for_select(employment_status_options,
-                                        pregnancy.employment_status),
-                                        autocomplete: 'off' %>
-        <%= f.select :income, 
-                     options_for_select(income_options,
-                                        pregnancy.income),
-                                        autocomplete: 'off' %>
-        <%= f.select :household_size, 
-                      options_for_select(household_size_options,
-                                         pregnancy.household_size),
-                                         label: 'People in household' %>
-        <%= f.select :insurance, 
-                     options_for_select(insurance_options,
-                                        pregnancy.insurance),
-                                        label: 'Patient insurance' %>
-        <%= f.select :referred_by,
-                     options_for_select(referred_by_options,
-                                        pregnancy.referred_by),
-                                        autocomplete: 'off' %>
-        <%= f.text_field :special_circumstances, autocomplete: 'Off' %>
+        <div class="info-form-right col-sm-6">
+          <%= f.select :employment_status, 
+                       options_for_select(employment_status_options,
+                                          pregnancy.employment_status),
+                                          autocomplete: 'off' %>
+          <%= f.select :income, 
+                       options_for_select(income_options,
+                                          pregnancy.income),
+                                          autocomplete: 'off' %>
+          <%= f.select :household_size, 
+                        options_for_select(household_size_options,
+                                           pregnancy.household_size),
+                                           label: 'People in household' %>
+          <%= f.select :insurance, 
+                       options_for_select(insurance_options,
+                                          pregnancy.insurance),
+                                          label: 'Patient insurance' %>
+          <%= f.select :referred_by,
+                       options_for_select(referred_by_options,
+                                          pregnancy.referred_by),
+                                          autocomplete: 'off' %>
+          <%= f.text_field :special_circumstances, autocomplete: 'Off' %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </section>
-

--- a/app/views/pregnancies/edit.html.erb
+++ b/app/views/pregnancies/edit.html.erb
@@ -19,7 +19,7 @@
       <%= render partial: 'pregnancies/patient_information', locals: { pregnancy: @pregnancy } %>
       <%= render partial: 'pregnancies/change_log', locals: { pregnancy: @pregnancy } %>
       <%= render partial: 'pregnancies/call_log', locals: { pregnancy: @pregnancy } %>
-      <%#= render partial: 'pregnancies/notes', locals: { note: @note } %>
+      <%= render partial: 'pregnancies/notes', locals: { pregnancy: @pregnancy, note: @note } %>
     </div>
   </div>
 <%# end %>

--- a/app/views/pregnancies/edit.html.erb
+++ b/app/views/pregnancies/edit.html.erb
@@ -2,24 +2,24 @@
 
 <%= render partial: "pledge", locals: { pregnancy: @pregnancy } %>
 
-<%= bootstrap_form_for @pregnancy do |f| %>
+<%#= bootstrap_form_for @pregnancy, remote: true do |f| %>
   <div id="patient_dashboard" class="row">
-    <%= render partial: 'pregnancies/patient_dashboard', locals: { f: f, pregnancy: @pregnancy } %>
+    <%= render partial: 'pregnancies/patient_dashboard', locals: { pregnancy: @pregnancy } %>
   </div>
 
   <div id="patient_detail" class="row">
     <div class="col-sm-4">
       <div id="menu" class="col-sm-9">
-        <%= render partial: 'pregnancies/menu', locals: { f: f, pregnancy: @pregnancy } %>
+        <%= render partial: 'pregnancies/menu', locals: { pregnancy: @pregnancy } %>
       </div>
     </div>
 
     <div id="sections" class="col-sm-8 tab-content">
-      <%= render partial: 'pregnancies/abortion_information', locals: { f: f, pregnancy: @pregnancy } %>
-      <%= render partial: 'pregnancies/patient_information', locals: { f: f, pregnancy: @pregnancy } %>
-      <%= render partial: 'pregnancies/change_log', locals: { f: f, pregnancy: @pregnancy } %>
+      <%= render partial: 'pregnancies/abortion_information', locals: { pregnancy: @pregnancy } %>
+      <%= render partial: 'pregnancies/patient_information', locals: { pregnancy: @pregnancy } %>
+      <%= render partial: 'pregnancies/change_log', locals: { pregnancy: @pregnancy } %>
       <%= render partial: 'pregnancies/call_log', locals: { pregnancy: @pregnancy } %>
-<% end %>
-      <%= render partial: 'pregnancies/notes', locals: { note: @note, pregnancy: @pregnancy } %>
+      <%#= render partial: 'pregnancies/notes', locals: { note: @note } %>
     </div>
   </div>
+<%# end %>

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -20,16 +20,12 @@ class NotesControllerTest < ActionController::TestCase
       end
     end
 
-    # it 'should respond success if the note submits' do
-    #   assert_response :success
-    # end
+    it 'should respond success if the note submits' do
+      assert_response :success
+    end
 
-    # it 'should render create.js.erb if it successfully saves' do
-    #   assert_template 'notes/create'
-    # end
-
-    it 'should redirect to edit pregnancy path if it saves' do
-      assert_redirected_to edit_pregnancy_path(@pregnancy)
+    it 'should render create.js.erb if it successfully saves' do
+      assert_template 'notes/create'
     end
 
     it 'should log the creating user' do
@@ -41,7 +37,7 @@ class NotesControllerTest < ActionController::TestCase
       assert_no_difference 'Pregnancy.find(@pregnancy).notes.count' do
         post :create, pregnancy_id: @pregnancy.id, note: @note, format: :js
       end
-      assert_redirected_to edit_pregnancy_path(@pregnancy)
+      assert_response :bad_request
     end
   end
 

--- a/test/controllers/pregnancies_controller_test.rb
+++ b/test/controllers/pregnancies_controller_test.rb
@@ -91,8 +91,14 @@ class PregnanciesControllerTest < ActionController::TestCase
       @pregnancy.reload
     end
 
-    it 'should redirect on completion' do # for now
-      assert_redirected_to edit_pregnancy_path(@pregnancy)
+    it 'should respond success on completion' do
+      assert_response :success
+    end
+
+    it 'should respond bad request on failure' do
+      @payload[:patient][:primary_phone] = nil
+      patch :update, id: @pregnancy, pregnancy: @payload
+      assert_response :bad_request
     end
 
     it 'should update pregnancy fields' do

--- a/test/integration/audit_trail_logging_test.rb
+++ b/test/integration/audit_trail_logging_test.rb
@@ -2,31 +2,42 @@ require 'test_helper'
 
 class AuditTrailLoggingTest < ActionDispatch::IntegrationTest
   before do
+    Capybara.current_driver = :poltergeist
     @user = create :user, email: 'first_user@email.com'
     @user2 = create :user, email: 'second_user@email.com'
     log_in_as @user
-    @patient = create :patient, name: 'tester', primary_phone: '1231231234', created_by: @user
-    @pregnancy = create :pregnancy, appointment_date: nil, patient: @patient, created_by: @user
+    @patient = create :patient, name: 'tester',
+                                primary_phone: '1231231234',
+                                created_by: @user
+    @pregnancy = create :pregnancy, appointment_date: nil,
+                                    patient: @patient,
+                                    created_by: @user
     visit edit_pregnancy_path(@pregnancy)
   end
 
-  describe 'A patient was created at some point' do
+  after do
+    Capybara.use_default_driver
+  end
+
+  describe 'A patient was created at some point', js: true do
     it 'posts changes and verifies audit trail in db' do
       assert_equal @patient.history_tracks.count, 1
       assert_equal @patient.created_by, @user
       assert_equal page.find(:id, 'pregnancy_patient_name').value, 'tester'
       fill_in 'First and last name', with: 'changed'
-      click_button 'TEMP: SAVE INFORMATION'
+      # click to a different field to trigger js
+      fill_in 'Phone number', with: @patient.primary_phone
       @patient.reload
       assert_equal @patient.name, 'changed'
       assert_equal @patient.history_tracks.count, 2
       assert_equal @patient.updated_by, @user
+
       sign_out
       log_in_as @user2
       visit edit_pregnancy_path(@pregnancy)
       assert_equal page.find(:id, 'pregnancy_patient_name').value, 'changed'
       fill_in 'First and last name', with: 'more change'
-      click_button 'TEMP: SAVE INFORMATION'
+      fill_in 'Phone number', with: @patient.primary_phone
       @patient.reload
       assert_equal @patient.name, 'more change'
       assert_equal @patient.history_tracks.count, 3

--- a/test/integration/note_creation_test.rb
+++ b/test/integration/note_creation_test.rb
@@ -2,12 +2,17 @@ require 'test_helper'
 
 class NoteCreationTest < ActionDispatch::IntegrationTest
   before do
+    Capybara.current_driver = :poltergeist
     @user = create :user
     log_in_as @user
     @patient = create :patient
     @pregnancy = create :pregnancy, patient: @patient
     visit edit_pregnancy_path(@pregnancy)
-    find('a', text: 'Notes').click
+    click_link 'Notes'
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 
   describe 'add patient pregnancy notes' do

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -2,12 +2,17 @@ require 'test_helper'
 
 class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   before do
+    Capybara.current_driver = :poltergeist
     @user = create :user
     @patient = create :patient
     @pregnancy = create :pregnancy, patient: @patient
     log_in_as @user
     visit edit_pregnancy_path @pregnancy
     has_text? 'First and last name' # wait until page loads
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 
   describe 'changing patient dashboard information' do
@@ -17,7 +22,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_last_menstrual_period_days').select '2 days'
       # fill_in 'Appointment date', with: '12/20/2016' PUNT
       fill_in 'Phone number', with: '123-666-8888'
-      click_button 'TEMP: SAVE INFORMATION'
+      click_away_from_field
+      # click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end
@@ -35,11 +41,13 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
   describe 'changing abortion information' do
     before do
+      click_link 'Abortion Information'
       fill_in 'Clinic name', with: 'Stub Clinic'
       # TODO: finish this after implementing clinic logic
       fill_in 'Abortion Cost:', with: '300'
       # TODO: and this, once we have funding sources
-      click_button 'TEMP: SAVE INFORMATION'
+      # click_button 'TEMP: SAVE INFORMATION'
+      click_away_from_field
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end
@@ -56,6 +64,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
   describe 'changing patient information' do
     before do
+      click_link 'Patient Information'
       fill_in 'Secondary person', with: 'Susie Everyteen Sr'
       fill_in 'Secondary phone', with: '123-666-7777'
       fill_in 'Age', with: '24'
@@ -70,13 +79,16 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_insurance').select 'Other state Medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
       fill_in 'Special circumstances', with: 'Stuff'
+      # send_keys :tab
 
-      click_button 'TEMP: SAVE INFORMATION'
+      click_away_from_field
+      # click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end
 
     it 'should alter the information' do
+      click_link 'Patient Information'
       within :css, '#patient_information' do
         assert has_field? 'Secondary person', with: 'Susie Everyteen Sr'
         assert has_field? 'Secondary phone', with: '123-666-7777'
@@ -94,5 +106,11 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert_equal 'Stuff', find('#pregnancy_special_circumstances').value
       end
     end
+  end
+
+  private
+
+  def click_away_from_field
+    fill_in 'First and last name', with: nil
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -22,8 +22,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_last_menstrual_period_days').select '2 days'
       # fill_in 'Appointment date', with: '12/20/2016' PUNT
       fill_in 'Phone number', with: '123-666-8888'
+
       click_away_from_field
-      # click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end
@@ -46,10 +46,10 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       # TODO: finish this after implementing clinic logic
       fill_in 'Abortion Cost:', with: '300'
       # TODO: and this, once we have funding sources
-      # click_button 'TEMP: SAVE INFORMATION'
       click_away_from_field
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
+      click_link 'Abortion Information'
     end
 
     it 'should alter the information' do
@@ -79,10 +79,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_insurance').select 'Other state Medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
       fill_in 'Special circumstances', with: 'Stuff'
-      # send_keys :tab
 
       click_away_from_field
-      # click_button 'TEMP: SAVE INFORMATION'
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

What started as just changing a controller to respond to js turned into an overhaul of the pregnancy edit form structure. 

TK: Fixing tests. But I wanted to get the PR in early so team ux knew this was coming down the pike, and so nobody else burned time on those issues.

Also TK: Adjusting `notes/create.js.erb` to append or reload the partial.

This pull request makes the following changes:
* Makes every pregnancy partial have its own form, to avoid form crosstalk
* Makes those forms submit on change
* Moves those forms and controller to be ajaxy
* Adjusts notes form and controller to be ajaxy too

It relates to the following issue #s: 
* Fixes #308 
* Fixes #404 