### PR TITLE
Turn off 'Remember me' option on sign in #388

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,10 @@ class User
   devise  :database_authenticatable,
           :registerable,
           :recoverable,
-          :rememberable,
           :trackable,
           :validatable,
           :lockable
+  # :rememberable
   # :confirmable
   # :timeoutable
 
@@ -31,7 +31,7 @@ class User
   field :reset_password_sent_at, type: Time
 
   ## Rememberable
-  field :remember_created_at, type: Time
+  # field :remember_created_at, type: Time
 
   ## Trackable
   field :sign_in_count,      type: Integer, default: 0


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turn off rememberable module and fields in user.rb

This pull request makes the following changes:
* Turn off rememberable module and fields in user.rb
* Left the rememberable settings in devise.rb untouched 

It relates to the following issue #s: 
* Turn off 'Remember me' option on sign in #388


