### PR TITLE
move session store to a mongoid table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'bootstrap_form-datetimepicker'
 gem 'quality', require: false
 gem 'nokogiri', '>= 1.6.8'
 gem 'newrelic_rpm'
+gem 'mongo_session_store-rails4'
 
 group :development do
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
       rails (>= 4.1)
     mongo (2.2.5)
       bson (~> 4.0)
+    mongo_session_store-rails4 (6.0.0)
+      actionpack (>= 3.1)
     mongoid (5.0.2)
       activemodel (~> 4.0)
       mongo (~> 2.1)
@@ -369,6 +371,7 @@ DEPENDENCIES
   mini_backtrace
   minitest-reporters
   minitest-spec-rails
+  mongo_session_store-rails4
   mongoid (~> 5.0.0)
   mongoid-history (~> 0.5.0)
   mongoid_userstamp

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_dcaf_case_management_session'
+Rails.application.config.session_store :mongoid_store


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Does what it says on the label.

This pull request makes the following changes:
* Installs a mongo gem that moves sessions to db
* Adjusts configs

It relates to the following issue #s: 
* Fixes #385 
