### PR TITLE
Add new patients to call list after creation, populate search result with info

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,13 +6,24 @@ class DashboardsController < ApplicationController
   def search
     patients = Patient.search params[:search]
     @results = []
-    patients.each do |patient|
-      @results << patient.pregnancies.most_recent
-    end
-    @patient = Patient.new
-    @pregnancy = @patient.pregnancies.new
+    patients.each { |patient| @results << patient.pregnancies.most_recent }
+
+    patient = Patient.new
+    @pregnancy = patient.pregnancies.new
     @today = Time.zone.today.to_date
+    @phone = searched_for_phone?(params[:search]) ? params[:search] : ''
+    @name = searched_for_name?(params[:search]) ? params[:search] : ''
 
     respond_to { |format| format.js }
+  end
+
+  private
+
+  def searched_for_phone?(query)
+    !/[a-z]/i.match query
+  end
+
+  def searched_for_name?(query)
+    /[a-z]/i.match query
   end
 end

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -11,6 +11,7 @@ class PregnanciesController < ApplicationController
     else
       flash[:alert] = 'An error prevented this patient from being saved'
     end
+    current_user.add_pregnancy @pregnancy
     redirect_to root_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,16 +3,14 @@ class UsersController < ApplicationController
   rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :bad_request }
 
   def add_pregnancy
-    current_user.pregnancies << @pregnancy
-    current_user.reload
+    current_user.add_pregnancy @pregnancy
     respond_to do |format|
       format.js { render template: 'users/refresh_pregnancies', layout: false }
     end
   end
 
   def remove_pregnancy
-    current_user.pregnancies.delete @pregnancy
-    current_user.reload
+    current_user.remove_pregnancy @pregnancy
     respond_to do |format|
       format.js { render template: 'users/refresh_pregnancies', layout: false }
     end
@@ -24,5 +22,4 @@ class UsersController < ApplicationController
     @pregnancy = Pregnancy.find params[:id]
     @urgent_pregnancies = Pregnancy.where(urgent_flag: true)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@ class User
   # :rememberable
   # :confirmable
 
-
   # Relationships
   has_and_belongs_to_many :pregnancies, inverse_of: :users
 
@@ -70,5 +69,15 @@ class User
 
   def recently_called?(preg)
     preg.calls.any? { |call| call.created_by_id == id && call.recent? }
+  end
+
+  def add_pregnancy(pregnancy)
+    pregnancies << pregnancy
+    reload
+  end
+
+  def remove_pregnancy(pregnancy)
+    pregnancies.delete pregnancy
+    reload
   end
 end

--- a/app/views/dashboards/search.js.erb
+++ b/app/views/dashboards/search.js.erb
@@ -1,6 +1,6 @@
 $('#search_results_shell').empty();
-<% if(@results.length == 0) %>
-  $("#search_results_shell").append("<%= escape_javascript(render partial: 'pregnancies/new_pregnancy', locals: { patient: @patient, pregnancy: @pregnancy }) %>");
+<% if @results.blank? %>
+  $("#search_results_shell").append("<%= escape_javascript(render partial: 'pregnancies/new_pregnancy', locals: { pregnancy: @pregnancy, name: @name, phone: @phone, today: @today }) %>");
 <% else %>
   $("#search_results_shell").append("<%= escape_javascript(render partial: 'dashboards/table_content', locals: { title: 'Search results', table_type: 'search_results', pregnancies: @results } ) %>");
 <% end %>

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -1,13 +1,13 @@
-<h3><small>Your search produced no results, so add a new patient:</small></h3>
+<h3><small>Add a new patient:</small></h3>
 
 <%= bootstrap_form_for pregnancy do |f| %>
-  <%= f.fields_for patient do |p| %>
+  <%= f.fields_for pregnancy.patient do |p| %>
     <div class="col-md-3">
       <div class="col-md-6">
-        <%= p.text_field :primary_phone, label: "Phone" %>
+        <%= p.text_field :primary_phone, label: 'Phone', value: phone %>
       </div>
       <div class="col-md-6">
-        <%= p.text_field :name, label: "Name" %>
+        <%= p.text_field :name, label: 'Name', value: name %>
       </div>
     </div>
   <% end %>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="col-md-2">
-    <%= f.date_field :initial_call_date, label: "Initial Call Date", value: @today,  required: "required" %>
+    <%= f.date_field :initial_call_date, label: "Initial Call Date", value: today,  required: "required" %>
   </div>
 
   <div class="col-sm-2">

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -1,4 +1,4 @@
-<h3><small>Add a new patient:</small></h3>
+<h3><small>Your search produced no results, so add a new patient:</small></h3>
 
 <%= bootstrap_form_for pregnancy do |f| %>
   <%= f.fields_for pregnancy.patient do |p| %>

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -15,7 +15,7 @@
       </div>
 
       <div class="info-form-right col-sm-6">
-        <%= bootstrap_form_for pregnancy, html: { id: 'urgents-form' }, html: { class: 'text-right text-danger edit_pregnancy' }, remote: true do |u| %>
+        <%= bootstrap_form_for pregnancy, html: { id: 'urgents-form', class: 'text-right text-danger edit_pregnancy' }, remote: true do |u| %>
           <%= u.check_box :urgent_flag, label: 'Flag this patient as urgent' %>
         <% end %>
       </div>        

--- a/test/integration/new_patient_creation_test.rb
+++ b/test/integration/new_patient_creation_test.rb
@@ -20,20 +20,33 @@ class NewPatientCreationTest < ActionDispatch::IntegrationTest
       fill_in 'Initial Call Date', with: '03/04/2016'
       find('button', text: /Create new patient/).trigger('click')
       sleep 1
-      fill_in 'search', with: 'Susan Everyteen 2'
-      click_button 'Search'
     end
 
     it 'should make that patient retrievable via search' do
-      within :css, '#search_results' do
+      fill_in 'search', with: 'Susan Everyteen 2'
+      click_button 'Search'
+
+      within :css, '#search_results_shell' do
         assert has_text? 'Susan Everyteen 2'
         assert has_text? '555-666-7777'
       end
     end
 
     it 'should make them viewable from the pregnancy edit page' do
+      fill_in 'search', with: 'Susan Everyteen 2'
+      click_button 'Search'
       click_link 'Susan Everyteen 2'
       assert current_path, edit_pregnancy_path(Pregnancy.last)
+    end
+
+    it 'should redirect to the root path' do
+      assert_equal current_path, authenticated_root_path
+    end
+
+    it 'should autopopulate the call list' do
+      within :css, '#call_list' do
+        assert has_link? 'Susan Everyteen 2'
+      end
     end
   end
 end

--- a/test/integration/record_lookup_test.rb
+++ b/test/integration/record_lookup_test.rb
@@ -33,8 +33,8 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
     end
   end
 
-  describe 'looking for someone who does not exist' do
-    it 'should display new pregnancy partial' do
+  describe 'looking for someone who does not exist', js: true do
+    it 'should display new pregnancy partial with name' do
       fill_in 'search', with: 'Nobody Real Here'
       click_button 'Search'
 
@@ -43,7 +43,9 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
         assert_equal 'Nobody Real Here', find_field('Name').value
         assert has_no_text? 'Search results'
       end
+    end
 
+    it 'should display new pregnancy partial with phone' do
       fill_in 'search', with: '111-111-1112'
       click_button 'Search'
 

--- a/test/integration/record_lookup_test.rb
+++ b/test/integration/record_lookup_test.rb
@@ -1,9 +1,14 @@
 require 'test_helper'
 
 class RecordLookupTest < ActionDispatch::IntegrationTest
-  def setup
+  before do
+    Capybara.current_driver = :poltergeist
     @user = create :user
     log_in_as @user
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 
   describe 'looking up someone who exists', js: true do
@@ -33,10 +38,19 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
       fill_in 'search', with: 'Nobody Real Here'
       click_button 'Search'
 
-      # TODO: improve by figuring out capybara CSS selectors and scoping
-      assert has_text? 'Your search produced no results, so add a new patient'
-      assert has_no_text? 'Nobody Real Here'
-      assert has_no_text? 'Search results'
+      within :css, '#search_results_shell' do
+        assert has_text? 'Your search produced no results, so add a new patient'
+        assert_equal 'Nobody Real Here', find_field('Name').value
+        assert has_no_text? 'Search results'
+      end
+
+      fill_in 'search', with: '111-111-1112'
+      click_button 'Search'
+
+      within :css, '#search_results_shell' do
+        assert has_text? 'Your search produced no results, so add a new patient'
+        assert_equal '111-111-1112', find_field('Phone').value
+      end
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -51,4 +51,23 @@ class UserTest < ActiveSupport::TestCase
       assert @user.recently_called? @pregnancy
     end
   end
+
+  describe 'pregnancy methods' do
+    before do
+      @pregnancy = create :pregnancy
+    end
+
+    it 'add pregnancy - should add a pregnancy to a set' do
+      assert_difference '@user.pregnancies.count', 1 do
+        @user.add_pregnancy @pregnancy
+      end
+    end
+
+    it 'remove pregnancy - should remove a pregnancy from a set' do
+      @user.add_pregnancy @pregnancy
+      assert_difference '@user.pregnancies.count', -1 do
+        @user.remove_pregnancy @pregnancy
+      end
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR adds a few case manager conveniences that are really, really, really annoying. Specifically, the new pregnancy form autopopulates the search params, and after you create a patient they get added to the call list.

This pull request makes the following changes:
* Moves `add_pregnancy` and `remove_pregnancy` to be model methods
* Tweaks dashboards controller to pass along name or phone
* Calls `User.add_pregnancy` within `PregnanciesController#create`
* Adds tests! Glorious tests

It relates to the following issue #s: 
* Fixes #397 
* Fixes #398 
