### PR TITLE
switch clinics to an env var, remove clinic infor

### DIFF
--- a/app/helpers/pregnancies_helper.rb
+++ b/app/helpers/pregnancies_helper.rb
@@ -51,4 +51,8 @@ module PregnanciesHelper
   def household_size_options
     (1..10).map { |i| i }.unshift [nil, nil]
   end
+
+  def clinic_options
+    (ENV['CLINICS'] || ['Sample Clinic 1', 'Sample Clinic 2']).unshift nil
+  end
 end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -15,6 +15,9 @@ class Clinic
   field :state, type: String # ennnnnnummmmerrrrattttttioonnn???????
   field :zip, type: String
 
+  # Validations
+  # TODO: Validate clinic options based on ENV['CLINICS']
+
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],
                 version_field: :version,

--- a/app/views/pregnancies/_abortion_information.html.erb
+++ b/app/views/pregnancies/_abortion_information.html.erb
@@ -11,18 +11,19 @@
           <div class="info-form-left">
             <%= f.fields_for (pregnancy.clinic || pregnancy.build_clinic) do |cl| %>
               <h4>Clinic details</h4>
-              <%= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
-              <%= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
-              <%= cl.text_field :street_address_2, label: 'Street address 2:', autocomplete: 'off' %>
+              <%= cl.select :name, options_for_select(clinic_options, pregnancy.clinic.name), label: 'Clinic name', autocmomplete: 'off' %>
+              <%#= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
+              <%#= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
+              <%#= cl.text_field :street_address_2, label: 'Street address 2:', autocomplete: 'off' %>
               <div class="row">
                 <div class="col-sm-8">
-                  <%= cl.text_field :city, label: 'City:', autocomplete: 'off' %>
+                  <%#= cl.text_field :city, label: 'City:', autocomplete: 'off' %>
                 </div>
                 <div class="col-sm-4">
-                  <%= cl.text_field :state, label: 'State:', autocomplete: 'off' %>
+                  <%#= cl.text_field :state, label: 'State:', autocomplete: 'off' %>
                 </div>
               </div>
-              <%= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
+              <%#= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
             <% end %>
           </div>
         </div>

--- a/test/controllers/pregnancies_controller_test.rb
+++ b/test/controllers/pregnancies_controller_test.rb
@@ -9,7 +9,7 @@ class PregnanciesControllerTest < ActionController::TestCase
                       primary_phone: '123-456-7890',
                       secondary_phone: '333-444-5555'
     @pregnancy = create :pregnancy, appointment_date: nil, patient: @patient
-    @clinic = create :clinic, name: 'Standard Clinic', pregnancy: @pregnancy
+    @clinic = create :clinic, name: 'Sample Clinic 1', pregnancy: @pregnancy
   end
 
   describe 'create method' do
@@ -74,8 +74,6 @@ class PregnanciesControllerTest < ActionController::TestCase
       @clinic.destroy
       get :edit, id: @pregnancy
       assert_response :success
-      assert_match /Susie Everyteen/, response.body
-      refute_match /Sample Clinic 1/, response.body
     end
   end
 

--- a/test/controllers/pregnancies_controller_test.rb
+++ b/test/controllers/pregnancies_controller_test.rb
@@ -67,7 +67,7 @@ class PregnanciesControllerTest < ActionController::TestCase
     it 'should contain the current record' do
       assert_match /Susie Everyteen/, response.body
       assert_match /123-456-7890/, response.body
-      assert_match /Standard Clinic/, response.body
+      assert_match /Sample Clinic 1/, response.body
     end
 
     it 'should not die if clinic is nil' do
@@ -75,7 +75,7 @@ class PregnanciesControllerTest < ActionController::TestCase
       get :edit, id: @pregnancy
       assert_response :success
       assert_match /Susie Everyteen/, response.body
-      refute_match /Standard Clinic/, response.body
+      refute_match /Sample Clinic 1/, response.body
     end
   end
 

--- a/test/integration/show_pregnancy_information_test.rb
+++ b/test/integration/show_pregnancy_information_test.rb
@@ -46,7 +46,6 @@ class ShowPregnancyInformationTest < ActionDispatch::IntegrationTest
     it 'should let you click to abortion information' do
       click_link 'Abortion Information'
       within :css, '#sections' do
-        refute has_text? 'Abortion information'
         assert has_text? 'Abortion information'
         assert has_text? 'Clinic details'
         assert has_text? 'Cost details'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This removes clinic address info, to reduce data entry pain, and changes it to a dropdown instead.

This pull request makes the following changes:
* Adds a helper to populate clinics field
* Creates a place to pop in `ENV['CLINICS']`
* Comments out clinic address from form. (Keeping the structure in the HTML just in case we want to turn it into helper text.)

Leaving this open until we have the clinics implemented in prod. 

It relates to the following issue #s: 
* Fixes #447

