### PR TITLE
adds parameters to be filtered from loggin

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,11 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+
+
+
+
+
+
+
+Rails.application.config.filter_parameters += [:password, :email, :name, :age, :employment_status, :primary_phone, :secondary_phone, :city, :state, :zip, :appointment_date, :insurance, :street_address_1, :street_address_2, :urgent_flag, :income, :special_circumstances, :procedure_cost, :procedure_date, :procedure_completed_date, :household_size, :full_text]


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
I included params to filter on inside /config/initializers/filter_parameter_logging.rb, anything thought could be sensitive.  In issue 382, Colin mentioned filtering on the pregnancy and patient model, but I also thought the addresses from the clinic model might be good to add here too, as well as the full_text attribute from the notes model in case people add names and other info inside their notes. 

It relates to the following issue #s: 
* Fixes #382

