### PR TITLE
Turn off registration but keep edit

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,7 @@ class User
           :trackable,
           :validatable,
           :lockable,
-          :timeoutable,
-          :invitable
+          :timeoutable
 
   # :rememberable
   # :confirmable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,14 @@ class User
 
   # Devise modules
   devise  :database_authenticatable,
-          :registerable,
+          # :registerable,
           :recoverable,
           :trackable,
           :validatable,
-          :lockable, 
-          :timeoutable
+          :lockable,
+          :timeoutable,
+          :invitable
+
   # :rememberable
   # :confirmable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,13 +4,12 @@ class User
 
   # Devise modules
   devise  :database_authenticatable,
-          # :registerable,
+          :registerable,
           :recoverable,
           :trackable,
           :validatable,
           :lockable,
           :timeoutable
-
   # :rememberable
   # :confirmable
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="authform">
   <h2>Edit <%= current_user.email %> (<%= current_user.name %>)</h2>
 
-  <%= bootstrap_form_for resource, as: resource_name, url: registration_path(resource_name), html: { method: :put } do |f| %>
+  <%= bootstrap_form_for resource, as: resource_name, url: '/users', html: { method: :put } do |f| %>
     <%= devise_error_messages! %>
 
     <h3>Change your account details</h3>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,9 +2,9 @@
   <%= link_to "Sign in", new_session_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end -%>
+<%#- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%#= link_to "Sign up", new_registration_path(resource_name) %><!-- <br /> -->
+<%# end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -1,4 +1,3 @@
-
 <ul class="nav navbar-nav navbar-right">
   <% if !user_signed_in? %>
     <li><%= link_to 'Sign in', new_user_session_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,9 @@ Rails.application.routes.draw do
     patch 'users/:user_id/remove_pregnancy/:id', to: 'users#remove_pregnancy', as: 'remove_pregnancy', defaults: { format: :js }
   end
   root :to => redirect('/users/sign_in')
-  devise_for :users
+  devise_for :users, skip: [:registrations]
+  as :user do
+    get '/users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
+    put '/users' => 'devise/registrations#update', as: 'registration'
+  end
 end

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -3,43 +3,49 @@ require 'test_helper'
 class SignUpTest < ActionDispatch::IntegrationTest
   before do
     visit root_path
-    click_link 'Sign up'
+    # click_link 'Sign up'
   end
 
-  describe 'creating a new user' do
-    before do
-      fill_in 'Email', with: Faker::Internet.email
-      fill_in 'Name', with: 'A Real Person'
-      fill_in 'Password', with: 'password', match: :prefer_exact
-      fill_in 'Password confirmation', with: 'password', match: :prefer_exact
-    end
-
-    it 'should create a user' do
-      assert_difference 'User.count', 1 do
-        click_button 'Sign up'
-      end
-    end
-
-    it 'should save that user name' do
-      click_button 'Sign up'
-      assert has_link? 'A Real Person'
+  describe 'should not let you create a user' do
+    it 'should not offer a sign up link' do
+      assert has_no_link? 'Sign up'
     end
   end
 
-  describe 'failure conditions' do
-    before do
-      @user = create :user
-    end
+  # describe 'creating a new user' do
+  #   before do
+  #     fill_in 'Email', with: Faker::Internet.email
+  #     fill_in 'Name', with: 'A Real Person'
+  #     fill_in 'Password', with: 'password', match: :prefer_exact
+  #     fill_in 'Password confirmation', with: 'password', match: :prefer_exact
+  #   end
 
-    it 'should not let you create a user twice' do
-      assert_no_difference 'User.count' do
-        fill_in 'Email', with: @user.email
-        fill_in 'Name', with: 'A Real Person'
-        fill_in 'Password', with: 'password', match: :prefer_exact
-        fill_in 'Password confirmation', with: 'password', match: :prefer_exact
-        click_button 'Sign up'
-        assert_text 'Email is already taken'
-      end
-    end
-  end
+  #   it 'should create a user' do
+  #     assert_difference 'User.count', 1 do
+  #       click_button 'Sign up'
+  #     end
+  #   end
+
+  #   it 'should save that user name' do
+  #     click_button 'Sign up'
+  #     assert has_link? 'A Real Person'
+  #   end
+  # end
+
+  # describe 'failure conditions' do
+  #   before do
+  #     @user = create :user
+  #   end
+
+  #   it 'should not let you create a user twice' do
+  #     assert_no_difference 'User.count' do
+  #       fill_in 'Email', with: @user.email
+  #       fill_in 'Name', with: 'A Real Person'
+  #       fill_in 'Password', with: 'password', match: :prefer_exact
+  #       fill_in 'Password confirmation', with: 'password', match: :prefer_exact
+  #       click_button 'Sign up'
+  #       assert_text 'Email is already taken'
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Had to yakshave this a bit but got it going. 

**Until we figure out an appropriate way to handle in release 2 (probably administrator invitation), we'll need to create new users from the rails console.**

This pull request makes the following changes:
* Removes non-password-editing routes from devise
* Turns off frontend user signup
* Fixes tests

It relates to the following issue #s: 
* Fixes #497
