### PR TITLE
Set timezone to UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module DcafCaseManagement
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Eastern Time (US & Canada)' # this is bad. Should hardset to UTC and find some way to programmatically determine timezone based on user.
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,11 +1,11 @@
 # Extends time class with convenience methods
 class Time
   def display_date
-    localtime.strftime("%Y-%m-%d")
+    getlocal.strftime("%Y-%m-%d")
   end
 
   def display_time
-    localtime.strftime("%-l:%M %P")
+    getlocal.strftime("%-l:%M %P")
   end
 
   def display_timestamp

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,11 +1,11 @@
 # Extends time class with convenience methods
 class Time
   def display_date
-    getlocal.strftime("%Y-%m-%d")
+    localtime.strftime("%Y-%m-%d")
   end
 
   def display_time
-    getlocal.strftime("%-l:%M %P")
+    localtime.strftime("%-l:%M %P")
   end
 
   def display_timestamp


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Brute-forced this a little bit. This changes the app config to use EST (The best time zone) so that timestamps show up right.

This pull request makes the following changes:
* Adjusts app config to hardset EST

It relates to the following issue #s: 
* Fixes #485 
