### PR TITLE
Add funding information to view; add secondary relationship field

### DIFF
--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -45,6 +45,8 @@ class PregnanciesController < ApplicationController
       :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income, :household_size, :insurance, :referred_by, :special_circumstances,
       # fields in notes
       :urgent_flag,
+      # temp fields for $
+      :patient_contribution, :naf_pledge, :dcaf_soft_pledge,
       # associated
       clinic: [:id, :name, :street_address_1, :street_address_2, :city, :state, :zip],
       patient: [:id, :name, :primary_phone, :secondary_person, :secondary_phone, :secondary_relationship]

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -47,7 +47,7 @@ class PregnanciesController < ApplicationController
       :urgent_flag,
       # associated
       clinic: [:id, :name, :street_address_1, :street_address_2, :city, :state, :zip],
-      patient: [:id, :name, :primary_phone, :secondary_person, :secondary_phone]
+      patient: [:id, :name, :primary_phone, :secondary_person, :secondary_phone, :secondary_relationship]
     )
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -33,16 +33,15 @@ class Patient
   mongoid_userstamp user_model: 'User'
 
   # Methods
-
-
   def self.search(name_or_phone_str) # Optimized Search the is case insensitive and phone number formatting agnostic
     clean_phone = name_or_phone_str.gsub(/\D/, '')
     formatted_phone = "#{clean_phone[0..2]}-#{clean_phone[3..5]}-#{clean_phone[6..10]}"
     begin
       name_matches = Patient.where name: /^#{Regexp.escape(name_or_phone_str)}$/i
+      secondary_name_matches = Patient.where secondary_person: /^#{Regexp.escape(name_or_phone_str)}$/i
       primary_matches = Patient.where primary_phone: formatted_phone
       secondary_matches = Patient.where secondary_phone: formatted_phone
-      (name_matches | primary_matches | secondary_matches)
+      (name_matches | secondary_name_matches | primary_matches | secondary_matches)
     end
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -12,6 +12,7 @@ class Patient
   field :primary_phone, type: String
   field :secondary_person, type: String
   field :secondary_phone, type: String
+  field :secondary_relationship, type: String
 
   # Validations
   validates :name,

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -45,6 +45,9 @@ class Pregnancy
   # Procedure result - generally for administrative use
   field :fax_received, type: Boolean
   field :procedure_cost, type: Integer
+  field :patient_contribution, type: Integer
+  field :naf_pledge, type: Integer
+  field :dcaf_soft_pledge, type: Integer
   field :procedure_date, type: DateTime
   field :procedure_completed_date, type: DateTime
   field :resolved_without_dcaf, type: Boolean

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -45,12 +45,14 @@ class Pregnancy
   # Procedure result - generally for administrative use
   field :fax_received, type: Boolean
   field :procedure_cost, type: Integer
-  field :patient_contribution, type: Integer
-  field :naf_pledge, type: Integer
-  field :dcaf_soft_pledge, type: Integer
   field :procedure_date, type: DateTime
   field :procedure_completed_date, type: DateTime
   field :resolved_without_dcaf, type: Boolean
+
+  # Temp fields associated with pledges: TEMPORARY
+  field :patient_contribution, type: Integer
+  field :naf_pledge, type: Integer
+  field :dcaf_soft_pledge, type: Integer
 
   # Validations
   validates :initial_call_date,

--- a/app/views/pregnancies/_abortion_information.html.erb
+++ b/app/views/pregnancies/_abortion_information.html.erb
@@ -10,7 +10,7 @@
         <div class="col-sm-6">
           <div class="info-form-left">
             <%= f.fields_for (pregnancy.clinic || pregnancy.build_clinic) do |cl| %>
-              <h4>Clinic details</h4>
+              <h3>Clinic details</h3>
               <%= cl.select :name, options_for_select(clinic_options, pregnancy.clinic.name), label: 'Clinic name', autocmomplete: 'off' %>
               <%#= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
               <%#= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
@@ -29,9 +29,11 @@
         </div>
         <div class="col-sm-6">
           <div class="info-form-right">
-            <h4>Cost details</h4>
-            <%= f.text_field :procedure_cost, label: 'Abortion Cost:', autocomplete: 'off' %>
-            <h5>PLACEHOLDER: Funding Sources</h5>
+            <h3>Cost details</h3>
+            <%= f.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', placeholder: '$' %>
+            <%= f.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', placeholder: '$' %>
+             <%= f.text_field :naf_pledge, label: 'National Abortion Fund pledge', autocomplete: 'off', placeholder: '$' %>
+               <%= f.text_field :dcaf_soft_pledge, label: 'DCAF soft pledge', autocomplete: 'off', placeholder: '$' %>
           </div>
         </div>
       </div>

--- a/app/views/pregnancies/_abortion_information.html.erb
+++ b/app/views/pregnancies/_abortion_information.html.erb
@@ -30,10 +30,10 @@
         <div class="col-sm-6">
           <div class="info-form-right">
             <h3>Cost details</h3>
-            <%= f.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', placeholder: '$' %>
-            <%= f.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', placeholder: '$' %>
-             <%= f.text_field :naf_pledge, label: 'National Abortion Fund pledge', autocomplete: 'off', placeholder: '$' %>
-               <%= f.text_field :dcaf_soft_pledge, label: 'DCAF soft pledge', autocomplete: 'off', placeholder: '$' %>
+            <%= f.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
+            <%= f.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
+             <%= f.text_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
+               <%= f.text_field :dcaf_soft_pledge, label: 'DCAF soft pledge', autocomplete: 'off', prepend: '$' %>
           </div>
         </div>
       </div>

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -35,8 +35,8 @@
           <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
           
           <h3> Secondary Contact</h3>
-           <%= f.fields_for pregnancy.patient do |p| %>
-            <%= p.text_field :secondary_person, autocomplete: 'off', label: 'Secondary contact first and last name' %>
+          <%= f.fields_for pregnancy.patient do |p| %>
+            <%= p.text_field :secondary_person, autocomplete: 'off', label: 'Secondary contact name' %>
             <%= p.text_field :secondary_phone, autocomplete: 'off', label: 'Secondary contact phone' %>
             <%= p.text_field :secondary_relationship, autocomplete: 'off', label: 'Secondary contact relationship' %>
           <% end %>

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -9,8 +9,6 @@
 
       <div class="row">
         <div class="info-form-left col-sm-6">
-          <strong>First and last name:</strong><br><%= pregnancy.patient.name %><br>
-          <strong>Phone number:</strong><br><%= pregnancy.patient.primary_phone %>
           <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
           <%= f.select :race_ethnicity, 
                        options_for_select(race_ethnicity_options,

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -9,11 +9,8 @@
 
       <div class="row">
         <div class="info-form-left col-sm-6">
-          <%= f.fields_for pregnancy.patient do |p| %>
-            <%= p.text_field :secondary_person, autocomplete: 'off' %>
-            <%= p.text_field :secondary_phone, autocomplete: 'off' %>
-          <% end %>
-    
+          <strong>First and last name:</strong><br><%= pregnancy.patient.name %><br>
+          <strong>Phone number:</strong><br><%= pregnancy.patient.primary_phone %>
           <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
           <%= f.select :race_ethnicity, 
                        options_for_select(race_ethnicity_options,
@@ -38,6 +35,13 @@
           </div>
 
           <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
+          
+          <h3> Secondary Contact</h3>
+           <%= f.fields_for pregnancy.patient do |p| %>
+            <%= p.text_field :secondary_person, autocomplete: 'off', label: 'Secondary contact first and last name' %>
+            <%= p.text_field :secondary_phone, autocomplete: 'off', label: 'Secondary contact phone' %>
+            <%= p.text_field :secondary_relationship, autocomplete: 'off', label: 'Secondary contact relationship' %>
+          <% end %>
         </div>
 
         <div class="info-form-right col-sm-6">

--- a/app/views/pregnancies/_pledge.html.erb
+++ b/app/views/pregnancies/_pledge.html.erb
@@ -9,7 +9,7 @@
 		<div class="pledge_form">
 			<div><span class="pledge_modal_category">Patient name:</span> <%= pregnancy.patient.name %></div>
 			<div><span class="pledge_modal_category">Patient ID:</span> <%= pregnancy.patient.primary_phone %></div>
-			<div><span class="pledge_modal_category">Pledge amount:</span> $100</div>
+			<div><span class="pledge_modal_category">Pledge amount:</span> $<%= pregnancy.dcaf_soft_pledge %> </div>
 			<div><span class="pledge_modal_category">Appointment date:</span> <%= pregnancy.appointment_date %></div>
 			<div><span class="pledge_modal_category">Clinic name:</span>Name</div>
 			<div><span class="pledge_modal_category">Clinic location:</span>City, State</div>

--- a/test/integration/record_lookup_test.rb
+++ b/test/integration/record_lookup_test.rb
@@ -13,7 +13,10 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
 
   describe 'looking up someone who exists', js: true do
     before do
-      @patient = create :patient, name: 'Susan Everyteen'
+      @patient = create :patient, name: 'Susan Everyteen',
+                                  primary_phone: '111-222-3333',
+                                  secondary_person: 'Yolo Goat',
+                                  secondary_phone: '222-333-4455'
       @pregnancy = create :pregnancy, patient: @patient
     end
 
@@ -24,12 +27,36 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
     end
 
     it 'should retrieve and display a record' do
-      fill_in 'search', with: 'Susan Everyteen'
+      fill_in 'search', with: 'susan everyteen'
       click_button 'Search'
 
       assert has_text? 'Search results'
       assert has_text? 'Susan Everyteen'
       assert_text @patient.primary_phone
+    end
+
+    it 'should be able to retrieve a record based on secondary name' do
+      fill_in 'search', with: 'Yolo Goat'
+      click_button 'Search'
+
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
+    end
+
+    it 'should be able to retrieve a record based on secondary phone' do
+      fill_in 'search', with: '222-333-4455'
+      click_button 'Search'
+
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
+    end
+
+    it 'should be able to retrieve a record regardless of phone formatting' do
+      fill_in 'search', with: '(111)2223333'
+      click_button 'Search'
+
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
     end
   end
 

--- a/test/integration/show_pregnancy_information_test.rb
+++ b/test/integration/show_pregnancy_information_test.rb
@@ -38,7 +38,8 @@ class ShowPregnancyInformationTest < ActionDispatch::IntegrationTest
     it 'should show patient information on open' do
       within :css, '#sections' do
         assert has_text? 'Patient information'
-        assert has_text? 'Secondary phone'
+        assert has_text? 'Age'
+        assert has_text? 'Secondary contact phone'
         assert has_text? 'Employment status'
       end
     end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -66,8 +66,9 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   describe 'changing patient information' do
     before do
       click_link 'Patient Information'
-      fill_in 'Secondary person', with: 'Susie Everyteen Sr'
-      fill_in 'Secondary phone', with: '123-666-7777'
+      fill_in 'Secondary contact name', with: 'Susie Everyteen Sr'
+      fill_in 'Secondary contact phone', with: '123-666-7777'
+      fill_in 'Secondary contact relationship', with: 'Friend'
       fill_in 'Age', with: '24'
       find('#pregnancy_race_ethnicity').select 'White/Caucasian'
       fill_in 'City', with: 'Washington'
@@ -89,8 +90,9 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     it 'should alter the information' do
       click_link 'Patient Information'
       within :css, '#patient_information' do
-        assert has_field? 'Secondary person', with: 'Susie Everyteen Sr'
-        assert has_field? 'Secondary phone', with: '123-666-7777'
+        assert has_field? 'Secondary contact name', with: 'Susie Everyteen Sr'
+        assert has_field? 'Secondary contact phone', with: '123-666-7777'
+        assert has_field? 'Secondary contact relationship', with: 'Friend'
         assert has_field? 'Age', with: '24'
         assert_equal 'White/Caucasian', find('#pregnancy_race_ethnicity').value
         assert has_field? 'City', with: 'Washington'

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -42,10 +42,13 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   describe 'changing abortion information' do
     before do
       click_link 'Abortion Information'
-      fill_in 'Clinic name', with: 'Stub Clinic'
+      find('#pregnancy_clinic_name').select 'Sample Clinic 1'
       # TODO: finish this after implementing clinic logic
-      fill_in 'Abortion Cost:', with: '300'
-      # TODO: and this, once we have funding sources
+      fill_in 'Abortion cost', with: '300'
+      fill_in 'Patient contribution', with: '200'
+      fill_in 'National Abortion Federation pledge', with: '50'
+      fill_in 'DCAF soft pledge', with: '25'
+
       click_away_from_field
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
@@ -53,14 +56,16 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     end
 
     # problematic test
-    # it 'should alter the information' do
-    #   within :css, '#abortion_information' do
-    #     assert has_field?('Clinic name', with: 'Stub Clinic')
-    #     # TK after clinic logic
-    #     assert has_field? 'Abortion Cost:', with: '300'
-    #     # TK after funding sources
-    #   end
-    # end
+    it 'should alter the information' do
+      within :css, '#abortion_information' do
+        assert_equal 'Sample Clinic 1', find('#pregnancy_clinic_name').value
+        # TK after clinic logic
+        assert has_field? 'Abortion cost', with: '300'
+        assert has_field? 'Patient contribution', with: '200'
+        assert has_field? 'National Abortion Federation pledge', with: '50'
+        assert has_field? 'DCAF soft pledge', with: '25'
+      end
+    end
   end
 
   describe 'changing patient information' do

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -21,7 +21,7 @@ class AuditTrailTest < ActiveSupport::TestCase
     it 'should track proper info' do
       # TODO: add pregnancy and clinic info
       tracked_fields =
-        %w(name primary_phone secondary_person secondary_phone updated_by_id)
+        %w(name primary_phone secondary_person secondary_phone secondary_relationship updated_by_id)
       assert_equal Patient.tracked_fields,
                    tracked_fields
     end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class PatientTest < ActiveSupport::TestCase
   before do
     @user = create :user
-    @patient = create :patient, created_by: @user
+    @patient = create :patient, secondary_phone: '111-222-3333',
+                                secondary_person: 'Yolo'
   end
 
   describe 'validations' do
@@ -51,6 +52,30 @@ class PatientTest < ActiveSupport::TestCase
   #   it 'should have only one active pregnancy' do
   #   end
   # end
+
+  describe 'search method' do
+    before do
+      @pt_1 = create :patient, name: 'Susan Sher', primary_phone: '123-456-6789'
+      @pt_2 = create :patient, name: 'Susan E', primary_phone: '123-456-6789', secondary_person: 'Yolo'
+      @pt_3 = create :patient, name: 'Susan A', secondary_phone: '999-999-9999'
+      [@pt_1, @pt_2, @pt_3].each do |pt|
+        create :pregnancy, patient: pt, created_by: @user
+      end
+    end
+
+    it 'should find a patient on name or secondary name' do
+      assert_equal Patient.search('Susan Sher').count, 1
+      assert_equal Patient.search('Yolo').count, 1
+    end
+
+    it 'should find multiple patients if there are multiple' do
+      assert_equal Patient.search('123-456-6789').count, 2
+    end
+
+    it 'should be able to find based on secondary phones too' do
+      assert_equal Patient.search('999-999-9999').count, 1
+    end
+  end
 
   describe 'mongoid attachments' do
     it 'should have timestamps from Mongoid::Timestamps' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -56,7 +56,7 @@ class PatientTest < ActiveSupport::TestCase
   describe 'search method' do
     before do
       @pt_1 = create :patient, name: 'Susan Sher', primary_phone: '123-456-6789'
-      @pt_2 = create :patient, name: 'Susan E', primary_phone: '123-456-6789', secondary_person: 'Yolo'
+      @pt_2 = create :patient, name: 'Susan E', primary_phone: '123-456-6789', secondary_person: 'Friend Ship'
       @pt_3 = create :patient, name: 'Susan A', secondary_phone: '999-999-9999'
       [@pt_1, @pt_2, @pt_3].each do |pt|
         create :pregnancy, patient: pt, created_by: @user
@@ -65,7 +65,7 @@ class PatientTest < ActiveSupport::TestCase
 
     it 'should find a patient on name or secondary name' do
       assert_equal Patient.search('Susan Sher').count, 1
-      assert_equal Patient.search('Yolo').count, 1
+      assert_equal Patient.search('Friend Ship').count, 1
     end
 
     it 'should find multiple patients if there are multiple' do

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -25,24 +25,6 @@ class PregnancyTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'search method' do
-    it 'should respond to search' do
-      assert Patient.respond_to? :search
-    end
-
-    it 'should find a patient' do
-      assert_equal Patient.search('Susan Smith').count, 1
-    end
-
-    it 'should find multiple patients if there are multiple' do
-      assert_equal Patient.search('123-456-6789').count, 2
-    end
-
-    it 'should be able to find based on secondary phones too' do
-      assert_equal Patient.search('999-999-9999').count, 1
-    end
-  end
-
   describe 'most_recent_note_display_text method' do
     before do
       @note = create :note, pregnancy: @pregnancy, full_text: (1..100).map(&:to_s).join('')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Picks up @dfelsent 's work to add financial / pledge portion, and shoehorn in secondary person information. Additional work is mostly just testing.

TODO still: Make sure that search works with secondary  people, both in the model and in the integration tests

This pull request makes the following changes:
* Adds $ to abortion information view
* Adds secondary contact info to view
* Makes appropriate model and controller changes
* Testin'

It relates to the following issue #s: 
* Fixes #480 
* Bumps #450 
