### PR TITLE
use automated build container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ For the rest of the setup, you have three options: Docker, installing everything
 
 ### Docker
 
-We've dockerized this app, to manage the dependencies and save us all the headache. If you've got [Docker installed already](https://docs.docker.com/engine/installation/), you can be up and running with four commands:
-* `docker-compose build # to install the dependencies`
+We've dockerized this app, to manage the dependencies and save us all the headache. If you've got [Docker installed already](https://docs.docker.com/engine/installation/), you can be up and running with two commands:
 * `docker-compose run web rake db:seed # to populate the database`
 * `docker-compose up`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 web:
-  build: .
+  image: mchelen/dcaf_case_management
   command: rails s -p 3000 -b 0.0.0.0
   volumes:
     - .:/usr/src/app


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!
- use docker hub automated build 

This pull request makes the following changes:
- create an automated build on docker hub
- point the `docker-compose.yml` file to use the built container
- update readme to deprecate `build` step

It relates to the following issue #s: 
- Fixes #491

You still need to create an automated build that points to this repo `colinxfleming/dcaf_case_management` so any updates will be automatically included in the built container: https://www.brianchristner.io/how-to-automate-docker-builds-end-to-end/ (just the first part "Create an Automated Build Docker Repository")

Then change the container name in `docker-compose.yml` and voila!
