### PR TITLE
Css load order

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,6 +1,7 @@
 /*
  *= require rails_bootstrap_forms
  *= require_tree ../../../vendor/assets/stylesheets/.
+ *= require_self
  *= require_tree .
 */
 

--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -44,12 +44,10 @@ $font-size: 17px;
   }
 
   li.active {
-    // padding-left: 0;
 
-
-    a, a:hover {
-      color: #5D3E8D !important;
-      background-color: white !important;
+    a, a:hover, a:active, a:focus {
+      color: #5D3E8D;
+      background-color: white;
     }
 
     a:before {


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

- load custom css after bootstrap

This pull request makes the following changes:
* custom css was being overridden by bootstrap css because bootstrap was being loaded afterward
* this changes the css load order to move custom css later on
* allows `!important` to be removed

It relates to the following issue #s: 
* Fixes #496
