### PR TITLE
add pregnancy status resolved_without_dcaf

### DIFF
--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -95,11 +95,11 @@ class Pregnancy
   end
 
   def status
-    # if resolved_without_dcaf
-    #   status = "Resolved Without DCAF"
+    if resolved_without_dcaf?
+      'Resolved Without DCAF'
     # elsif pledge_status?(:paid)
     #   status = "Pledge Paid"
-    if pledge_sent?
+    elsif pledge_sent?
       'Pledge sent'
     elsif appointment_date
       'Fundraising'

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -70,8 +70,10 @@ class PregnancyTest < ActiveSupport::TestCase
     # it 'should update to "Pledge Paid" after a pledge has been paid' do
     # end
 
-    # it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
-    # end
+    it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
+      @pregnancy.resolved_without_dcaf = true
+      assert_equal 'Resolved Without DCAF', @pregnancy.status
+    end
   end
 
   describe 'contact_made? method' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* edit pregnancy status method for resolved_without_dcaf
* add test to update pregnancy status

It relates to the following issue #s: 
* Mark patients as resolved without help from dcaf #528

