### PR TITLE
Add mark as resolved to views

### DIFF
--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -38,7 +38,7 @@ class PregnanciesController < ApplicationController
       # fields in create
       :voicemail_ok, :initial_call_date,
       # fields in dashboard
-      :status, :last_menstrual_period_days, :last_menstrual_period_weeks, :appointment_date,
+      :status, :last_menstrual_period_days, :last_menstrual_period_weeks, :appointment_date, :resolved_without_dcaf,
       # fields in abortion info
       :procedure_cost,
       # fields in patient info

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -95,11 +95,11 @@ class Pregnancy
   end
 
   def status
-    # if resolved_without_dcaf
-    #   status = "Resolved Without DCAF"
+    if resolved_without_dcaf?
+      'Resolved Without DCAF'
     # elsif pledge_status?(:paid)
     #   status = "Pledge Paid"
-    if pledge_sent?
+    elsif pledge_sent?
       'Pledge sent'
     elsif appointment_date
       'Fundraising'

--- a/app/views/pregnancies/_abortion_information.html.erb
+++ b/app/views/pregnancies/_abortion_information.html.erb
@@ -25,8 +25,13 @@
               </div>
               <%#= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
             <% end %>
+
+            <%= f.form_group :resolved_without_dcaf, label: { text: 'Resolved without assistance from DCAF' } do %>
+              <%= f.check_box :resolved_without_dcaf, label: '' %>
+            <% end %>
           </div>
         </div>
+
         <div class="col-sm-6">
           <div class="info-form-right">
             <h3>Cost details</h3>

--- a/app/views/pregnancies/_patient_dashboard.html.erb
+++ b/app/views/pregnancies/_patient_dashboard.html.erb
@@ -23,6 +23,8 @@
   </div>
 
   <div class="col-sm-4">
-    <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD', help: "Approx gestation at appt: #{pregnancy.last_menstrual_period_at_appt}" %>
+    <div class="row">
+      <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD', help: "Approx gestation at appt: #{pregnancy.last_menstrual_period_at_appt}" %>
+    </div>
   </div>
 <% end %>

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -48,6 +48,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       fill_in 'Patient contribution', with: '200'
       fill_in 'National Abortion Federation pledge', with: '50'
       fill_in 'DCAF soft pledge', with: '25'
+      check 'Resolved without assistance from DCAF'
 
       click_away_from_field
       visit authenticated_root_path
@@ -64,6 +65,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'Patient contribution', with: '200'
         assert has_field? 'National Abortion Federation pledge', with: '50'
         assert has_field? 'DCAF soft pledge', with: '25'
+        assert_equal '1', find('#pregnancy_resolved_without_dcaf').value
       end
     end
   end
@@ -79,6 +81,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       fill_in 'City', with: 'Washington'
       fill_in 'State', with: 'DC'
       fill_in 'ZIP', with: '90210'
+      check 'Voicemail OK?'
 
       find('#pregnancy_employment_status').select 'Part-time'
       find('#pregnancy_income').select '$30,000-34,999 ($577-672/week)'
@@ -110,6 +113,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert_equal 'Other state Medicaid', find('#pregnancy_insurance').value
         assert_equal 'Other abortion fund', find('#pregnancy_referred_by').value
         assert_equal 'Stuff', find('#pregnancy_special_circumstances').value
+        assert_equal '1', find('#pregnancy_voicemail_ok').value
       end
     end
   end

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -70,8 +70,10 @@ class PregnancyTest < ActiveSupport::TestCase
     # it 'should update to "Pledge Paid" after a pledge has been paid' do
     # end
 
-    # it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
-    # end
+    it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
+      @pregnancy.resolved_without_dcaf = true
+      assert_equal 'Resolved Without DCAF', @pregnancy.status
+    end
   end
 
   describe 'contact_made? method' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds @ashlynnpai 's resolved without assistance from dcaf work to the views; alters integration tests appropriately as well.

I didn't have a better place to put it, so I tossed it as a checkbox under the `Abortion information` section. 

Screenshot: 

![image](https://cloud.githubusercontent.com/assets/3866868/17079426/12c0ca82-50de-11e6-8e75-ba01036ba020.png)


It relates to the following issue #s: 
* Fixes #528 
