### PR TITLE
Add unit test for user-pregnancies relationship

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -70,4 +70,22 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'relationships' do
+    before do
+      @pregnancy = create :pregnancy
+      @pregnancy_2 = create :pregnancy
+      @user.pregnancies << @pregnancy
+      @user.pregnancies << @pregnancy_2
+      @user_2 = create :user
+    end
+
+    it 'should have any belong to many pregnancies' do
+      [@pregnancy, @pregnancy_2].each do |preg|
+        [@user, @user_2].each { |user| user.add_pregnancy preg }
+      end
+
+      assert_equal @user.pregnancies, @user_2.pregnancies
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a quick unit test to ensure a pregnancy can be on multiple call lists.

This pull request makes the following changes:
* Does what it says on the label

It relates to the following issue #s: 
* Fixes #275 

