### PR TITLE
WIP - Fix integration test from hell

### DIFF
--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -39,7 +39,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
     end
 
     it 'should be viewable on the call log' do
-      visit edit_pregnancy_path(@pregnancy)
+      visit edit_pregnancy_path @pregnancy
+      wait_for_page_to_load
       find('a', text: 'Call Log').click
 
       within :css, '#call_log' do
@@ -53,7 +54,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   describe 'logging multiple calls' do
     # problematic test
-    it 'should let you save more than one reached patient call' do
+    it 'should let you save more than one call' do
       3.times do
         visit authenticated_root_path
         fill_in 'search', with: 'Susan Everyteen'
@@ -72,7 +73,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
   end
 
   ['Left voicemail', "Couldn't reach patient"].each do |call_status|
-    describe "logging #{call_status}", js: true do
+    describe "logging #{call_status}" do
       before do
         @link_text =  if call_status == 'Left voicemail'
                         'I left a voicemail for the patient'
@@ -86,25 +87,26 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       end
 
       # problematic test
-      # it "should close the modal when clicking #{call_status}" do
-      #   assert_equal current_path, authenticated_root_path
-      #   assert has_no_text? 'Call Susan Everyteen now'
-      #   assert has_no_link? @link_text
-      # end
+      it "should close the modal when clicking #{call_status}" do
+        assert_equal current_path, authenticated_root_path
+        assert has_no_text? 'Call Susan Everyteen now'
+        assert has_no_link? @link_text
+      end
 
       # problematic test
-      # it "should be visible on the call log after clicking #{call_status}" do
-      #   assert_equal current_path, authenticated_root_path
-      #   visit edit_pregnancy_path(@pregnancy)
-      #   find('a', text: 'Call Log').click
+      it "should be visible on the call log after clicking #{call_status}" do
+        assert_equal current_path, authenticated_root_path
+        visit edit_pregnancy_path @pregnancy
+        wait_for_page_to_load
+        find('a', text: 'Call Log').click
 
-      #   within :css, '#call_log' do
-      #     assert has_text? @timestamp.display_date
-      #     assert has_text? @timestamp.display_time
-      #     assert has_text? call_status
-      #     assert has_text? @user.name
-      #   end
-      # end
+        within :css, '#call_log' do
+          assert has_text? @timestamp.display_date
+          assert has_text? @timestamp.display_time
+          assert has_text? call_status
+          assert has_text? @user.name
+        end
+      end
     end
   end
 

--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -42,6 +42,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       visit edit_pregnancy_path @pregnancy
       wait_for_page_to_load
       find('a', text: 'Call Log').click
+      wait_for_section_to_load 'call_log'
 
       within :css, '#call_log' do
         assert has_text? @timestamp.display_date
@@ -66,6 +67,8 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       visit edit_pregnancy_path @pregnancy
       wait_for_page_to_load
       find('a', text: 'Call Log').click
+      wait_for_section_to_load 'call_log'
+
       within :css, '#call_log' do
         assert has_content? 'Reached patient', count: 3
       end
@@ -99,6 +102,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         visit edit_pregnancy_path @pregnancy
         wait_for_page_to_load
         find('a', text: 'Call Log').click
+        wait_for_section_to_load 'call_log'
 
         within :css, '#call_log' do
           assert has_text? @timestamp.display_date
@@ -114,5 +118,9 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   def wait_for_page_to_load
     has_text? 'Submit pledge'
+  end
+
+  def wait_for_section_to_load(section)
+    find("##{section}")
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -95,6 +95,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       visit edit_pregnancy_path @pregnancy
     end
 
+    # problematic test
     it 'should alter the information' do
       click_link 'Patient Information'
       within :css, '#patient_information' do


### PR DESCRIPTION
Rehab work on the integration tests to use more matchers, so that the call logging integration tests don't randomly fail for no goddamned good reason.

If I can get this to pass five times in a row I'm going to call it good. 

It relates to the following issue #s: 
* Fixes #375 
