### PR TITLE
Smallnotes

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -63,6 +63,9 @@ $font-size: 17px;
 .margin-bottom {
   margin-bottom: 100px;
 }
+.margin-bottom-sm {
+  margin-bottom: 50px;
+}
 
 // increase size of text in form fields
 .form-control {
@@ -156,7 +159,7 @@ section {
   @extend .btn-xs;
 }
 
-// Search result 
+// Search result
 // shell styling
 .form-group input {
   &[type="date"]::-webkit-inner-spin-button {

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -1,10 +1,10 @@
 <section id="notes" class="notes tab-pane">
   <div class="col-sm-12 margin-bottom">
-    <%= bootstrap_form_for [pregnancy, note], html: { id: 'notes-form' }, remote: true do |f| %>  
+    <%= bootstrap_form_for [pregnancy, note], html: { id: 'notes-form' }, remote: true do |f| %>
     <div class="row">
       <div class="info-form-left col-sm-12">
         <h2>Notes</h2>
-        <%= f.text_area :full_text, size: '20x10', placeholder: 'Enter notes here', hide_label: true %>
+        <%= f.text_area :full_text, size: '20x5', placeholder: 'Enter notes here', hide_label: true %>
       </div>
     </div>
 
@@ -18,7 +18,7 @@
         <%= bootstrap_form_for pregnancy, html: { id: 'urgents-form', class: 'text-right text-danger edit_pregnancy' }, remote: true do |u| %>
           <%= u.check_box :urgent_flag, label: 'Flag this patient as urgent' %>
         <% end %>
-      </div>        
+      </div>
     </div>
   </div>
 

--- a/app/views/pregnancies/_notes.html.erb
+++ b/app/views/pregnancies/_notes.html.erb
@@ -1,5 +1,5 @@
 <section id="notes" class="notes tab-pane">
-  <div class="col-sm-12 margin-bottom">
+  <div class="col-sm-12 margin-bottom-sm">
     <%= bootstrap_form_for [pregnancy, note], html: { id: 'notes-form' }, remote: true do |f| %>
     <div class="row">
       <div class="info-form-left col-sm-12">


### PR DESCRIPTION
Hi! This reduces the size of the textarea for the notes entry box so the notes log is visible without scrolling. The size of the textarea was half the issue; the notes area also had a `margin-bottom` class which pushed the notes log down by 100px, great for other areas but too much for this one. I changed the class to a new `margin-bottom-sm` and defined it so it only pushes it down by 50px. 

This pull request makes the following changes:
* reduced the size of the textarea in the markup for app/views/pregnancies/_notes.html.erb;
* changes the class of the notes area from `margin-bottom` to `margin-bottom-sm`;
* defines `margin-bottom-sm` as having a margin-bottom of 50px. 

It relates to the following issue #s: 
* Fixes #525
<img width="793" alt="screen shot 2016-07-29 at 4 53 31 pm" src="https://cloud.githubusercontent.com/assets/15959851/17263090/0c690b4e-55ad-11e6-891c-01a612e93717.png">

