### PR TITLE
adds jQuery to close popups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,7 @@
 //= require_tree ../../../vendor/assets/javascripts/.
 
 $(document).ready(function(){
-  // TODO migrate to pledges.coffee
+	// TODO migrate to pledges.coffee
 	$('.pledge_submit').click(function () {
 		$('.pledge_modal_screen1').hide();
 		$('.pledge_modal_screen2').show();
@@ -33,7 +33,7 @@ $(document).ready(function(){
 	$('.pledge_continue').click(function () {
 		$('.pledge_modal_screen2').hide();
 		$('.pledge_modal_screen3').show();
-				console.log('click');
+		console.log('click');
 	});
 
 	$('.pledge_back_review').click(function () {
@@ -45,5 +45,16 @@ $(document).ready(function(){
 		$('.pledge_modal_screen3').hide();
 	});
 
-  $('[data-toggle="toggle"]').bootstrapToggle();
-})
+	$('[data-toggle="toggle"]').bootstrapToggle();
+
+// dismisses popovers when you click any non-popover space on the body
+	$('body').on('click', function (e) {
+		$('[data-toggle="popover"]').each(function () {
+			//the 'is' for buttons that trigger popups
+			if (!$(this).is(e.target) && $('.popover').has(e.target).length === 0) {
+				// the `.data().inState.click` fixes a bug that required two clicks to open a popoever after dismissing one
+				$(this).popover('hide').data('bs.popover').inState.click = false;
+			}
+		});
+	});
+});


### PR DESCRIPTION
This adds some jQuery to dismiss the popups you see when you click a note in Dashboard view. Now when you click anywhere that is not in the active popup the popup is dismissed. This also prevents there from being more than one popup open at a time. 

This pull request makes the following changes:
* jQuery added to app/assets/javascripts/application.js
* It works but I'm too noobie to write a test for it

It relates to the following issue #s: 
* Fixes #530

