### PR TITLE
Spanishcheckbox

### DIFF
--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -36,7 +36,7 @@ class PregnanciesController < ApplicationController
   def pregnancy_params
     params.require(:pregnancy).permit(
       # fields in create
-      :voicemail_ok, :initial_call_date,
+      :voicemail_ok, :initial_call_date, :spanish,
       # fields in dashboard
       :status, :last_menstrual_period_days, :last_menstrual_period_weeks, :appointment_date, :resolved_without_dcaf,
       # fields in abortion info

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -24,7 +24,7 @@ class Pregnancy
   field :last_menstrual_period_days, type: Integer
   field :voicemail_ok, type: Boolean, default: false
   field :line, type: String # DC, MD, VA
-  field :language, type: String
+  field :spanish, type: Boolean
   field :appointment_date, type: Date
   field :urgent_flag, type: Boolean
 

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -16,16 +16,16 @@
                                           label: 'Race / Ethnicity',
                                           autocomplete: 'off' %>
 
+          <%= f.form_group :spanish do %>
+            <!-- <div class='bootstrap_toggle_spacing'> -->
+          <%= f.check_box :spanish, label: 'Spanish Only' %>
+            <%#= f.check_box :spanish, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
+            <!-- </div> -->
+          <% end %>
           <%= f.form_group :voicemail_ok do %>
             <!-- <div class='bootstrap_toggle_spacing'> -->
               <%= f.check_box :voicemail_ok, label: 'Voicemail OK?' %>
               <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
-            <!-- </div> -->
-          <% end %>
-          <%= f.form_group :spanish do %>
-            <!-- <div class='bootstrap_toggle_spacing'> -->
-              <%= f.check_box :spanish, label: 'Spanish Only' %>
-              <%#= f.check_box :spanish, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
             <!-- </div> -->
           <% end %>
 

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -10,16 +10,22 @@
       <div class="row">
         <div class="info-form-left col-sm-6">
           <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
-          <%= f.select :race_ethnicity, 
+          <%= f.select :race_ethnicity,
                        options_for_select(race_ethnicity_options,
                                           pregnancy.race_ethnicity),
-                                          label: 'Race / Ethnicity', 
+                                          label: 'Race / Ethnicity',
                                           autocomplete: 'off' %>
 
-          <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
+          <%= f.form_group :voicemail_ok do %>
             <!-- <div class='bootstrap_toggle_spacing'> -->
-              <%= f.check_box :voicemail_ok, label: '' %>
+              <%= f.check_box :voicemail_ok, label: 'Voicemail OK?' %>
               <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
+            <!-- </div> -->
+          <% end %>
+          <%= f.form_group :spanish do %>
+            <!-- <div class='bootstrap_toggle_spacing'> -->
+              <%= f.check_box :spanish, label: 'Spanish Only' %>
+              <%#= f.check_box :spanish, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
             <!-- </div> -->
           <% end %>
 
@@ -33,7 +39,7 @@
           </div>
 
           <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
-          
+
           <h3>Other Contact</h3>
           <%= f.fields_for pregnancy.patient do |p| %>
             <%= p.text_field :other_contact, autocomplete: 'off', label: 'Other contact name' %>
@@ -43,19 +49,19 @@
         </div>
 
         <div class="info-form-right col-sm-6">
-          <%= f.select :employment_status, 
+          <%= f.select :employment_status,
                        options_for_select(employment_status_options,
                                           pregnancy.employment_status),
                                           autocomplete: 'off' %>
-          <%= f.select :income, 
+          <%= f.select :income,
                        options_for_select(income_options,
                                           pregnancy.income),
                                           autocomplete: 'off' %>
-          <%= f.select :household_size, 
+          <%= f.select :household_size,
                         options_for_select(household_size_options,
                                            pregnancy.household_size),
                                            label: 'People in household' %>
-          <%= f.select :insurance, 
+          <%= f.select :insurance,
                        options_for_select(insurance_options,
                                           pregnancy.insurance),
                                           label: 'Patient insurance' %>

--- a/test/factories/pregnancy.rb
+++ b/test/factories/pregnancy.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :pregnancy do
     patient
     line 'DC'
-    language 'English'
+    spanish false
     initial_call_date { 2.days.ago }
     created_by { FactoryGirl.create(:user) }
   end


### PR DESCRIPTION
This adds a `Spanish Only` checkbox to the patient information area.

This pull request makes the following changes:
* Changes the `language` field in the Pregnancy model to `spanish` and makes the field a boolean;
* adds `spanish` to the strong params in the pregnancies_controller
* adds a checkbox to app/views/pregnancies/_patient_information.html.erb

<img width="474" alt="screen shot 2016-08-04 at 8 46 46 pm" src="https://cloud.githubusercontent.com/assets/15959851/17422931/abb298c4-5a84-11e6-866f-91b309fcbbef.png">

It relates to the following issue #s: 
* Fixes #455

