### PR TITLE
Remix voicemail preferences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'quality', require: false
 gem 'nokogiri', '>= 1.6.8'
 gem 'newrelic_rpm'
 gem 'mongo_session_store-rails4'
+gem 'mongoid-enum'
 
 group :development do
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
     mongoid-compatibility (0.4.0)
       activesupport
       mongoid (>= 2.0)
+    mongoid-enum (0.4.0)
+      mongoid (~> 5.0)
     mongoid-history (0.5.0)
       activesupport
       easy_diff
@@ -373,6 +375,7 @@ DEPENDENCIES
   minitest-spec-rails
   mongo_session_store-rails4
   mongoid (~> 5.0.0)
+  mongoid-enum
   mongoid-history (~> 0.5.0)
   mongoid_userstamp
   newrelic_rpm

--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -36,7 +36,7 @@ class PregnanciesController < ApplicationController
   def pregnancy_params
     params.require(:pregnancy).permit(
       # fields in create
-      :voicemail_ok, :initial_call_date, :spanish,
+      :voicemail_preference, :initial_call_date, :spanish,
       # fields in dashboard
       :status, :last_menstrual_period_days, :last_menstrual_period_weeks, :appointment_date, :resolved_without_dcaf,
       # fields in abortion info

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -17,7 +17,7 @@ module DashboardsHelper
   end
 
   def voicemail_options
-    enum_text = { default: 'No instructions; no ID VM',
+    enum_text = { not_specified: 'No instructions; no ID VM',
                   no: 'Do not leave a voicemail',
                   yes: 'Voicemail OK' }
     vm_options = Pregnancy::VOICEMAIL_PREFERENCE

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -15,4 +15,13 @@ module DashboardsHelper
     return nil unless text.length > 41
     "<span class='glyphicon glyphicon-plus-sign' aria-hidden='true' data-toggle='popover' data-placement='bottom' title='Most recent note' data-content='#{text}'></span><span class='sr-only'>Full note</span>".html_safe
   end
+
+  def voicemail_options
+    enum_text = { default: 'No instructions; no ID VM',
+                  no: 'Do not leave a voicemail',
+                  yes: 'Voicemail OK' }
+    vm_options = Pregnancy::VOICEMAIL_PREFERENCE
+
+    vm_options.map { |option| [enum_text[option], option] }
+  end
 end

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -6,8 +6,6 @@ class Pregnancy
   include Mongoid::Userstamp
   include LastMenstrualPeriodHelper
 
-  enum :voicemail_preference, [:default, :no, :yes]
-
   # Relationships
   belongs_to :patient
   has_and_belongs_to_many :users, inverse_of: :pregnancies
@@ -25,7 +23,7 @@ class Pregnancy
   field :initial_call_date, type: Date
   field :last_menstrual_period_weeks, type: Integer
   field :last_menstrual_period_days, type: Integer
-  field :voicemail_preference, type: Integer, default: 0
+  enum :voicemail_preference, [:not_specified, :no, :yes]
   field :line, type: String # DC, MD, VA
   field :spanish, type: Boolean
   field :appointment_date, type: Date

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -1,9 +1,12 @@
 class Pregnancy
   include Mongoid::Document
+  include Mongoid::Enum
   include Mongoid::Timestamps
   include Mongoid::History::Trackable
   include Mongoid::Userstamp
   include LastMenstrualPeriodHelper
+
+  enum :voicemail_preference, [:default, :no, :yes]
 
   # Relationships
   belongs_to :patient
@@ -22,7 +25,7 @@ class Pregnancy
   field :initial_call_date, type: Date
   field :last_menstrual_period_weeks, type: Integer
   field :last_menstrual_period_days, type: Integer
-  field :voicemail_ok, type: Boolean, default: false
+  field :voicemail_preference, type: Integer, default: 0
   field :line, type: String # DC, MD, VA
   field :spanish, type: Boolean
   field :appointment_date, type: Date

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -11,11 +11,15 @@
 
           <p><%= link_to "I reached the patient", pregnancy_calls_path(p, call: { status: 'Reached patient'} ), method: :post, class: 'btn btn-primary', id: 'calls-btn' %></p>
 
-          <% unless p.voicemail_ok? %>
+          <% if p.voicemail_preference == :no %>
             <p class='text-danger'><strong>Do not leave this patient a voicemail</strong></p>
+          <% elsif p.voicemail_preference == :yes %>
+            <p class='text-success'>Voicemail OK; Okay to identify as DCAF</p>
+            <p><%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true, class: 'calls-response' %></p>
+          <% else %>
+            <p class='text-warning'><strong>Voicemail OK; Do not identify as DCAF</strong></p>
+            <p><%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true, class: 'calls-response' %></p>
           <% end %>
-
-          <p><%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true, class: 'calls-response' %></p>
 
           <p><%= link_to "I couldn't reach the patient", pregnancy_calls_path(p, call: { status: "Couldn't reach patient" } ), method: :post, remote: true, class: 'calls-response' %></p>
         </div><!-- calls-layout -->

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -16,7 +16,7 @@
           <% elsif p.voicemail_preference == :yes %>
             <p class='text-success'>Voicemail OK; Okay to identify as DCAF</p>
             <p><%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true, class: 'calls-response' %></p>
-          <% else %>
+          <% elsif p.voicemail_preference == :not_specified %>
             <p class='text-warning'><strong>Voicemail OK; Do not identify as DCAF</strong></p>
             <p><%= link_to "I left a voicemail for the patient", pregnancy_calls_path(p, call: { status: "Left voicemail" } ), method: :post, remote: true, class: 'calls-response' %></p>
           <% end %>

--- a/app/views/pregnancies/_new_pregnancy.html.erb
+++ b/app/views/pregnancies/_new_pregnancy.html.erb
@@ -26,11 +26,8 @@
   </div>
 
   <div class="col-sm-2">
-    <%= f.form_group :voicemail_ok, label: { text: 'Voicemail OK?' } do %>
-      <div class='bootstrap_toggle_spacing'>
-        <%= f.check_box :voicemail_ok, data: { toggle: 'toggle', on: 'Yes', off: 'No' }, label: '' %>
-      </div>
-    <% end %>
+    <%= f.select :voicemail_preference, 
+                 options_for_select(voicemail_options) %>
   </div>
 
   <div class="col-sm-2">

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -22,12 +22,9 @@
             <%#= f.check_box :spanish, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
             <!-- </div> -->
           <% end %>
-          <%= f.form_group :voicemail_ok do %>
-            <!-- <div class='bootstrap_toggle_spacing'> -->
-              <%= f.check_box :voicemail_ok, label: 'Voicemail OK?' %>
-              <%#= f.check_box :voicemail_ok, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
-            <!-- </div> -->
-          <% end %>
+
+          <%= f.select :voicemail_preference, 
+                       options_for_select(voicemail_options) %>
 
           <div class="row">
             <div class="col-sm-8">

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -17,14 +17,12 @@
                                           autocomplete: 'off' %>
 
           <%= f.form_group :spanish do %>
-            <!-- <div class='bootstrap_toggle_spacing'> -->
-          <%= f.check_box :spanish, label: 'Spanish Only' %>
-            <%#= f.check_box :spanish, data: { toggle: 'toggle', yes: 'Yes', no: 'No' },label: '' %>
-            <!-- </div> -->
+            <%= f.check_box :spanish, label: 'Spanish Only' %>
           <% end %>
 
           <%= f.select :voicemail_preference, 
-                       options_for_select(voicemail_options) %>
+                       options_for_select(voicemail_options,
+                                          pregnancy.voicemail_preference) %>
 
           <div class="row">
             <div class="col-sm-8">

--- a/test/helpers/dashboards_helper_test.rb
+++ b/test/helpers/dashboards_helper_test.rb
@@ -30,4 +30,12 @@ class DashboardsHelperTest < ActionView::TestCase
       refute_nil plus_sign_glyphicon over_40_char
     end
   end
+
+  describe 'voicemail_options' do
+    it 'should return an array based on pregnancy.voicemail_options' do
+      Pregnancy::VOICEMAIL_PREFERENCE.each do |pref|
+        refute_empty voicemail_options.select { |opt| opt[1] == pref }
+      end
+    end
+  end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -109,7 +109,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'State', with: 'DC'
         assert has_field? 'ZIP', with: '90210'
         assert has_field? 'Special circumstances', with: 'Stuff'
-        assert_equal 'Voicemail OK', find('#pregnancy_voicemail_preference').value
+        assert_equal 'yes', find('#pregnancy_voicemail_preference').value
         assert has_checked_field? 'Spanish Only'
 
         assert_equal 'Part-time', find('#pregnancy_employment_status').value
@@ -118,7 +118,6 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert_equal 'Other state Medicaid', find('#pregnancy_insurance').value
         assert_equal 'Other abortion fund', find('#pregnancy_referred_by').value
         assert_equal 'Stuff', find('#pregnancy_special_circumstances').value
-        assert_equal '1', find('#pregnancy_voicemail_ok').value
       end
     end
   end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -81,7 +81,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       fill_in 'City', with: 'Washington'
       fill_in 'State', with: 'DC'
       fill_in 'ZIP', with: '90210'
-      check 'Voicemail OK?'
+      find('#pregnancy_voicemail_preference').select 'Voicemail OK'
       check 'Spanish Only'
 
       find('#pregnancy_employment_status').select 'Part-time'
@@ -109,7 +109,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'State', with: 'DC'
         assert has_field? 'ZIP', with: '90210'
         assert has_field? 'Special circumstances', with: 'Stuff'
-        assert has_checked_field? 'Voicemail OK?'
+        assert_equal 'Voicemail OK', find('#pregnancy_voicemail_preference').value
         assert has_checked_field? 'Spanish Only'
 
         assert_equal 'Part-time', find('#pregnancy_employment_status').value

--- a/test/integration/voicemail_preference_in_call_modal_test.rb
+++ b/test/integration/voicemail_preference_in_call_modal_test.rb
@@ -14,7 +14,7 @@ class VoicemailPreferenceInCallModalTest < ActionDispatch::IntegrationTest
   describe 'different voicemail preferences and links' do
     describe 'no voicemail' do
       before do
-        @pregnancy.voicemail_preference = 'no'
+        @pregnancy.voicemail_preference = :no
         @pregnancy.save
         open_call_modal_for @pregnancy
       end
@@ -27,8 +27,6 @@ class VoicemailPreferenceInCallModalTest < ActionDispatch::IntegrationTest
 
     describe 'voicemail ok but no id' do
       before do
-        @pregnancy.voicemail_preference = 'default'
-        @pregnancy.save
         open_call_modal_for @pregnancy
       end
 
@@ -40,7 +38,7 @@ class VoicemailPreferenceInCallModalTest < ActionDispatch::IntegrationTest
 
     describe 'voicemail ok' do
       before do
-        @pregnancy.voicemail_preference = 'yes'
+        @pregnancy.voicemail_preference = :yes
         @pregnancy.save
         open_call_modal_for @pregnancy
       end

--- a/test/integration/voicemail_preference_in_call_modal_test.rb
+++ b/test/integration/voicemail_preference_in_call_modal_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class VoicemailPreferenceInCallModalTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+    @patient = create :patient, name: 'Susan Everyteen'
+    @pregnancy = create :pregnancy, patient: @patient
+    @user = create :user
+    log_in_as @user
+  end
+
+  after { Capybara.use_default_driver }
+
+  describe 'different voicemail preferences and links' do
+    describe 'no voicemail' do
+      before do
+        @pregnancy.voicemail_preference = 'no'
+        @pregnancy.save
+        open_call_modal_for @pregnancy
+      end
+
+      it 'should have warning text and no link' do
+        assert has_text? 'Do not leave this patient a voicemail'
+        refute has_link? 'I left a voicemail for the patient'
+      end
+    end
+
+    describe 'voicemail ok but no id' do
+      before do
+        @pregnancy.voicemail_preference = 'default'
+        @pregnancy.save
+        open_call_modal_for @pregnancy
+      end
+
+      it 'should have warning text and a link' do
+        assert has_text? 'Voicemail OK; Do not identify as DCAF'
+        assert has_link? 'I left a voicemail for the patient'
+      end
+    end
+
+    describe 'voicemail ok' do
+      before do
+        @pregnancy.voicemail_preference = 'yes'
+        @pregnancy.save
+        open_call_modal_for @pregnancy
+      end
+
+      it 'should have goahead text and a link' do
+        assert has_text? 'Voicemail OK; Okay to identify as DCAF'
+        assert has_link? 'I left a voicemail for the patient'
+      end
+    end
+  end
+
+  private
+
+  def open_call_modal_for(pregnancy)
+    fill_in 'search', with: pregnancy.patient.name
+    click_button 'Search'
+    find("a[href='#call-#{pregnancy.patient.primary_phone_display}']").click
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This remixes voicemail preferences to be one of three instead of yes/no, and adjusts the call modal to have different text based on the setting. (And also adds tests.)

This pull request makes the following changes:
* Changes boolean `voicemail_ok` to enum `voicemail_preference` (default of not_specified)
* Changes the new call modal to display different text (and possibly take away voicemail link) based on `voicemail_preference`
* Adds integration test for new call modal text, since it's kind of important to not screw that up

@mebates @lwaldsc @NerdyGirl537 can you review the text I wrote (below in the pictures) and stamp approved?

Pictures of the new call modals with each setting:

<img width="470" alt="screen shot 2016-08-07 at 2 52 29 am" src="https://cloud.githubusercontent.com/assets/3866868/17460995/c16a38ee-5c4a-11e6-8748-2cd9b70b4ccc.png">
<img width="459" alt="screen shot 2016-08-07 at 2 52 00 am" src="https://cloud.githubusercontent.com/assets/3866868/17460997/c16d7c20-5c4a-11e6-9d78-9f4a2495ab77.png">
<img width="478" alt="screen shot 2016-08-07 at 2 52 14 am" src="https://cloud.githubusercontent.com/assets/3866868/17460996/c16ae924-5c4a-11e6-95ad-88250926cef9.png">

Picture of the voicemail preference options (set in `dashboards_helper`):
![screen shot 2016-08-07 at 2 59 05 am](https://cloud.githubusercontent.com/assets/3866868/17461002/f4ac84aa-5c4a-11e6-8cd7-e632814ce0ed.png)

It relates to the following issue #s: 
* Fixes #522 
