### PR TITLE
rake task for clearing call list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,7 @@ require File.expand_path('../config/application', __FILE__)
 # require 'dawn/tasks' # Comment this out until dawnscanner gets better
 
 Rails.application.load_tasks
+
+task :clear_call_lists => :environment do
+  User.all.each{ |u| u.clear_call_list }
+end

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -5,6 +5,15 @@ class Pregnancy
   include Mongoid::Userstamp
   include LastMenstrualPeriodHelper
 
+  STATUSES = {
+    no_contact: 'No Contact Made',
+    needs_appt: 'Needs Appointment',
+    fundraising: 'Fundraising',
+    pledge_sent: 'Pledge Sent',
+    pledge_paid: 'Pledge Paid',
+    resolved: 'Resolved Without DCAF'
+  }
+
   # Relationships
   belongs_to :patient
   has_and_belongs_to_many :users, inverse_of: :pregnancies
@@ -102,17 +111,17 @@ class Pregnancy
 
   def status
     if resolved_without_dcaf?
-      'Resolved Without DCAF'
+      STATUSES[:resolved]
     # elsif pledge_status?(:paid)
-    #   status = "Pledge Paid"
+    #   STATUSES[:pledge_paid]
     elsif pledge_sent?
-      'Pledge sent'
+      STATUSES[:pledge_sent]
     elsif appointment_date
-      'Fundraising'
+      STATUSES[:fundraising]
     elsif contact_made?
-      'Needs Appointment'
+      STATUSES[:needs_appt]
     else
-      'No Contact Made'
+      STATUSES[:no_contact]
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,4 +80,10 @@ class User
     pregnancies.delete pregnancy
     reload
   end
+
+  def clear_call_list
+    pregnancies.each do |p|
+      pregnancies.delete(p) unless p.status == Pregnancy::STATUSES[:no_contact]
+    end
+  end
 end

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -29,7 +29,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
 
       click_link 'Dashboard'
       visit edit_pregnancy_path @pregnancy
-      assert has_text? 'Pledge sent'
+      assert has_text? Pregnancy::STATUSES[:pledge_sent]
     end
   end
 end

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -57,27 +57,27 @@ class PregnancyTest < ActiveSupport::TestCase
 
     describe 'status method' do
       it 'should default to "No Contact Made" when a pregnancy has no calls' do
-        assert_equal 'No Contact Made', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:no_contact], @pregnancy.status
       end
 
       it 'should default to "No Contact Made" on a pregnancy left voicemail' do
         create :call, pregnancy: @pregnancy, status: 'Left voicemail'
-        assert_equal 'No Contact Made', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:no_contact], @pregnancy.status
       end
 
       it 'should update to "Needs Appointment" once patient has been reached' do
         create :call, pregnancy: @pregnancy, status: 'Reached patient'
-        assert_equal 'Needs Appointment', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:needs_appt], @pregnancy.status
       end
 
       it 'should update to "Fundraising" once an appointment has been made' do
         @pregnancy.appointment_date = '01/01/2017'
-        assert_equal 'Fundraising', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:fundraising], @pregnancy.status
       end
 
       it 'should update to "Sent Pledge" after a pledge has been sent' do
         @pregnancy.pledge_sent = true
-        assert_equal 'Pledge sent', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:pledge_sent], @pregnancy.status
       end
 
       # it 'should update to "Pledge Paid" after a pledge has been paid' do
@@ -85,7 +85,7 @@ class PregnancyTest < ActiveSupport::TestCase
 
       it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
         @pregnancy.resolved_without_dcaf = true
-        assert_equal 'Resolved Without DCAF', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:resolved], @pregnancy.status
       end
     end
 


### PR DESCRIPTION
This pull request makes the following changes:
* create a clear_call_list method on User
* create a clear_call_lists rake task
* create a STATUSES hash on Pregnancy

It relates to the following issue #s: 
* Bumps #118

@colinxfleming I think this addresses the criteria described in #188. However, would it be more useful for case managers if call were cleared based on whether they were reached *during the last shift* specifically? This just looks at overall status. aka whether the patient has ever been reached
