### PR TITLE
Split household size into children and adults

### DIFF
--- a/app/controllers/pregnancies_controller.rb
+++ b/app/controllers/pregnancies_controller.rb
@@ -42,7 +42,7 @@ class PregnanciesController < ApplicationController
       # fields in abortion info
       :procedure_cost,
       # fields in patient info
-      :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income, :household_size, :insurance, :referred_by, :special_circumstances,
+      :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income, :household_size_adults, :household_size_children, :insurance, :referred_by, :special_circumstances,
       # fields in notes
       :urgent_flag,
       # temp fields for $

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -36,7 +36,8 @@ class Pregnancy
   field :county, type: String
   field :race_ethnicity, type: String
   field :employment_status, type: String
-  field :household_size, type: Integer
+  field :household_size_children, type: Integer
+  field :household_size_adults, type: Integer
   field :insurance, type: String
   field :income, type: String
   field :referred_by, type: String

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -57,10 +57,22 @@
                        options_for_select(income_options,
                                           pregnancy.income),
                                           autocomplete: 'off' %>
-          <%= f.select :household_size,
-                        options_for_select(household_size_options,
-                                           pregnancy.household_size),
-                                           label: 'People in household' %>
+
+          <div class="row">
+            <div class="col-sm-6">
+              <%= f.select :household_size_adults,
+                            options_for_select(household_size_options,
+                                               pregnancy.household_size_adults),
+                                               label: 'Adults in household', help: '(including self)' %>
+            </div>
+            <div class="col-sm-6">
+              <%= f.select :household_size_children,
+                            options_for_select(household_size_options,
+                                               pregnancy.household_size_children),
+                                               label: 'Minors in household' %>              
+            </div>
+          </div>
+
           <%= f.select :insurance,
                        options_for_select(insurance_options,
                                           pregnancy.insurance),

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -63,7 +63,7 @@
               <%= f.select :household_size_adults,
                             options_for_select(household_size_options,
                                                pregnancy.household_size_adults),
-                                               label: 'Adults in household', help: '(including self)' %>
+                                               label: 'Adults in household', help: '(including patient)' %>
             </div>
             <div class="col-sm-6">
               <%= f.select :household_size_children,

--- a/app/views/pregnancies/_patient_information.html.erb
+++ b/app/views/pregnancies/_patient_information.html.erb
@@ -63,7 +63,8 @@
               <%= f.select :household_size_adults,
                             options_for_select(household_size_options,
                                                pregnancy.household_size_adults),
-                                               label: 'Adults in household', help: '(including patient)' %>
+                                               label: 'Adults in household',
+                                               help: '(including patient)' %>
             </div>
             <div class="col-sm-6">
               <%= f.select :household_size_children,

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -86,7 +86,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
       find('#pregnancy_employment_status').select 'Part-time'
       find('#pregnancy_income').select '$30,000-34,999 ($577-672/week)'
-      find('#pregnancy_household_size').select '1'
+      find('#pregnancy_household_size_adults').select '1'
+      find('#pregnancy_household_size_children').select '3'
       find('#pregnancy_insurance').select 'Other state Medicaid'
       find('#pregnancy_referred_by').select 'Other abortion fund'
       fill_in 'Special circumstances', with: 'Stuff'
@@ -114,7 +115,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
         assert_equal 'Part-time', find('#pregnancy_employment_status').value
         assert_equal '$30,000-34,999 ($577-672/week)', find('#pregnancy_income').value
-        assert_equal '1', find('#pregnancy_household_size').value
+        assert_equal '1', find('#pregnancy_household_size_adults').value
+        assert_equal '3', find('#pregnancy_household_size_children').value
         assert_equal 'Other state Medicaid', find('#pregnancy_insurance').value
         assert_equal 'Other abortion fund', find('#pregnancy_referred_by').value
         assert_equal 'Stuff', find('#pregnancy_special_circumstances').value


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Splits household size into children and adults, and adjusts tests.

This pull request makes the following changes:
* Does what it says on the label

![image](https://cloud.githubusercontent.com/assets/3866868/17463685/576775e8-5c99-11e6-8f0c-eda0d9ea44ec.png)

It relates to the following issue #s: 
* Fixes #224 
