### PR TITLE
rake task for clearing call list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,7 @@ require File.expand_path('../config/application', __FILE__)
 # require 'dawn/tasks' # Comment this out until dawnscanner gets better
 
 Rails.application.load_tasks
+
+task :clear_call_lists => :environment do
+  User.all.each{ |u| u.clear_call_list }
+end

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -29,4 +29,8 @@ class Call
   def recent?
     updated_at > 8.hours.ago ? true : false
   end
+
+  def reached?
+    status == 'Reached patient'
+  end
 end

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -6,6 +6,15 @@ class Pregnancy
   include Mongoid::Userstamp
   include LastMenstrualPeriodHelper
 
+  STATUSES = {
+    no_contact: 'No Contact Made',
+    needs_appt: 'Needs Appointment',
+    fundraising: 'Fundraising',
+    pledge_sent: 'Pledge Sent',
+    pledge_paid: 'Pledge Paid',
+    resolved: 'Resolved Without DCAF'
+  }
+
   # Relationships
   belongs_to :patient
   has_and_belongs_to_many :users, inverse_of: :pregnancies
@@ -104,17 +113,17 @@ class Pregnancy
 
   def status
     if resolved_without_dcaf?
-      'Resolved Without DCAF'
+      STATUSES[:resolved]
     # elsif pledge_status?(:paid)
-    #   status = "Pledge Paid"
+    #   STATUSES[:pledge_paid]
     elsif pledge_sent?
-      'Pledge sent'
+      STATUSES[:pledge_sent]
     elsif appointment_date
-      'Fundraising'
+      STATUSES[:fundraising]
     elsif contact_made?
-      'Needs Appointment'
+      STATUSES[:needs_appt]
     else
-      'No Contact Made'
+      STATUSES[:no_contact]
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,15 +72,11 @@ class User
   # AND they would otherwise be in the call list
 
   def recently_called_pregnancies
-    pregnancies.select { |p| recently_called?(p) }
+    pregnancies.select { |p| recently_called_by_user?(p) }
   end
 
   def call_list_pregnancies
-    pregnancies.reject { |p| recently_called?(p) }
-  end
-
-  def recently_called?(preg)
-    preg.calls.any? { |call| call.created_by_id == id && call.recent? }
+    pregnancies.reject { |p| recently_called_by_user?(p) }
   end
 
   def add_pregnancy(pregnancy)
@@ -107,6 +103,12 @@ class User
     ordered_pregnancies
   end
 
+  def clear_call_list
+    pregnancies.each do |p|
+      pregnancies.delete(p) if recently_reached_by_user?(p)
+    end
+  end
+
   private
 
   def verify_password_complexity
@@ -120,5 +122,13 @@ class User
     return false if (password =~ /[0-9]/).nil?
     # Make sure the word password isn't in there
     return false if !(password.downcase[/(password|dcaf)/]).nil?
+  end
+
+  def recently_reached_by_user?(preg)
+    preg.calls.any? { |call| call.created_by_id == id && call.recent? && call.reached? }
+  end
+
+  def recently_called_by_user?(preg)
+    preg.calls.any? { |call| call.created_by_id == id && call.recent? }
   end
 end

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -29,7 +29,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
 
       click_link 'Dashboard'
       visit edit_pregnancy_path @pregnancy
-      assert has_text? 'Pledge sent'
+      assert has_text? Pregnancy::STATUSES[:pledge_sent]
     end
   end
 end

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -57,27 +57,27 @@ class PregnancyTest < ActiveSupport::TestCase
 
     describe 'status method' do
       it 'should default to "No Contact Made" when a pregnancy has no calls' do
-        assert_equal 'No Contact Made', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:no_contact], @pregnancy.status
       end
 
       it 'should default to "No Contact Made" on a pregnancy left voicemail' do
         create :call, pregnancy: @pregnancy, status: 'Left voicemail'
-        assert_equal 'No Contact Made', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:no_contact], @pregnancy.status
       end
 
       it 'should update to "Needs Appointment" once patient has been reached' do
         create :call, pregnancy: @pregnancy, status: 'Reached patient'
-        assert_equal 'Needs Appointment', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:needs_appt], @pregnancy.status
       end
 
       it 'should update to "Fundraising" once an appointment has been made' do
         @pregnancy.appointment_date = '01/01/2017'
-        assert_equal 'Fundraising', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:fundraising], @pregnancy.status
       end
 
       it 'should update to "Sent Pledge" after a pledge has been sent' do
         @pregnancy.pledge_sent = true
-        assert_equal 'Pledge sent', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:pledge_sent], @pregnancy.status
       end
 
       # it 'should update to "Pledge Paid" after a pledge has been paid' do
@@ -85,7 +85,7 @@ class PregnancyTest < ActiveSupport::TestCase
 
       it 'should update to "Resolved Without DCAF" if pregnancy is resolved' do
         @pregnancy.resolved_without_dcaf = true
-        assert_equal 'Resolved Without DCAF', @pregnancy.status
+        assert_equal Pregnancy::STATUSES[:resolved], @pregnancy.status
       end
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -55,10 +55,20 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 1, @user.call_list_pregnancies.count
     end
 
-    it 'should accurately flag a pregnancy as recently called or not' do
-      refute @user.recently_called? @pregnancy
-      @call = create :call, pregnancy: @pregnancy, created_by: @user
-      assert @user.recently_called? @pregnancy
+    it 'should clear calls when patient has been reached' do
+      assert_equal 0, @user.recently_called_pregnancies.count
+      @call = create :call, pregnancy: @pregnancy, created_by: @user, status: 'Reached patient'
+      assert_equal 1, @user.recently_called_pregnancies.count
+      @user.clear_call_list
+      assert_equal 0, @user.recently_called_pregnancies.count
+    end
+
+    it 'should not clear calls when patient has not been reached' do
+      assert_equal 0, @user.recently_called_pregnancies.count
+      @call = create :call, pregnancy: @pregnancy, created_by: @user, status: 'Left voicemail'
+      assert_equal 1, @user.recently_called_pregnancies.count
+      @user.clear_call_list
+      assert_equal 1, @user.recently_called_pregnancies.count
     end
   end
 


### PR DESCRIPTION
This pull request makes the following changes:
* create a clear_call_list method on User
* create a clear_call_lists rake task
* create a STATUSES hash on Pregnancy

It relates to the following issue #s:
* Bumps #118

Worth noting: right now recent calls are those made within the last 8 hours. If we want to run this task at 4am, we may want to make some adjustments