### PR TITLE
Finish complex password requirement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,8 @@ class User
   private
 
   def verify_password_complexity
+    # Enforce length of at least ten
+    return false unless password.length >= 8
     # we want at least one lower case
     return false if (password =~ /[a-z]/).nil?
     # We want at least one uppercase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,7 @@ class User
   validate :secure_password
 
   def secure_password
+    return true if password.nil?
     pc = verify_password_complexity
     if pc == false
       errors.add :password, 'Password must include at least one lowercase ' \

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,23 +55,14 @@ class User
   validates :email, :name, presence: true
   validate :secure_password
 
-   def secure_password
-     pc = password_complexity
-     if pc == false
-       errors.add :password, "must include at least one lowercase letter, one uppercase letter, and one digit. Forbidden words include DCAF and password."
-     end
-   end
-
-   def password_complexity
-     # we want at least one lower case
-     return false if (password =~ /[a-z]/).nil?
-     # We want at least one uppercase
-     return false if (password =~ /[A-Z]/).nil?
-     # We want at least one digit
-     return false if (password =~ /[0-9]/).nil?
-     # Make sure the word password isn't in there
-     return false if !(password.downcase[/(password|dcaf)/]).nil?
-   end
+  def secure_password
+    pc = verify_password_complexity
+    if pc == false
+      errors.add :password, 'Password must include at least one lowercase ' \
+                            'letter, one uppercase letter, and one digit. ' \
+                            'Forbidden words include DCAF and password.'
+    end
+  end
 
   # ticket 241 recently called criteria:
   # someone has a call from the current_user
@@ -98,5 +89,18 @@ class User
   def remove_pregnancy(pregnancy)
     pregnancies.delete pregnancy
     reload
+  end
+
+  private
+
+  def verify_password_complexity
+    # we want at least one lower case
+    return false if (password =~ /[a-z]/).nil?
+    # We want at least one uppercase
+    return false if (password =~ /[A-Z]/).nil?
+    # We want at least one digit
+    return false if (password =~ /[0-9]/).nil?
+    # Make sure the word password isn't in there
+    return false if !(password.downcase[/(password|dcaf)/]).nil?
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@ User.destroy_all
 
 # Create two test users
 user = User.create name: 'testuser', email: 'test@test.com',
-                   password: 'password', password_confirmation: 'password'
+                   password: 'P4ssword', password_confirmation: 'P4ssword'
 user2 = User.create name: 'testuser2', email: 'test2@test.com',
-                    password: 'password', password_confirmation: 'password'
+                    password: 'P4ssword', password_confirmation: 'P4ssword'
 
 # Create ten patients
 10.times do |i|
@@ -78,4 +78,4 @@ patient_in_completed_calls.calls.create status: 'Left voicemail',
 puts "Seed completed! Inserted #{Patient.count} patient objects" \
      "and #{Pregnancy.count} associated pregnancy objects.\n" \
      "User created! Credentials are as follows: " \
-     "EMAIL: #{user.email} PASSWORD: password"
+     "EMAIL: #{user.email} PASSWORD: P4ssword"

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
       "billy#{n}@everyteen.com"
     end
     password 'FCZCidQP4C8GTz'
+    password_confirmation 'FCZCidQP4C8GTz'
   end
 end

--- a/test/integration/update_user_info_test.rb
+++ b/test/integration/update_user_info_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class UpdateUserInfoTest < ActionDispatch::IntegrationTest
   before do
+    Capybara.current_driver = :poltergeist
     @user = create :user
     log_in_as @user
     visit edit_user_registration_path
@@ -24,12 +25,12 @@ class UpdateUserInfoTest < ActionDispatch::IntegrationTest
     end
 
     it 'should let you change your password' do
-      fill_in 'Password', with: 'another_password'
-      fill_in 'Password confirmation', with: 'another_password'
+      fill_in 'Password', with: 'Different_P4ss'
+      fill_in 'Password confirmation', with: 'Different_P4ss'
       fill_in 'Current password', with: @user.password
       click_button 'Update info'
       sign_out
-      @user.password = 'another_password'
+      @user.password = 'Different_P4ss'
       log_in_as @user
       refute has_text? 'Signed in successfully.'
     end
@@ -38,7 +39,7 @@ class UpdateUserInfoTest < ActionDispatch::IntegrationTest
       fill_in 'First and last name', with: 'Bad Name'
       click_button 'Update info'
       assert_text "Current password can't be blank"
-      fill_in 'Current password', with: 'not_a_real_password'
+      fill_in 'Current password', with: 'not_a_real_pAssw0rd'
       click_button 'Update info'
       assert_text 'Current password is invalid'
       assert_no_text 'Bad Name'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,11 +21,14 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-      it "passwords should be complex" do
-        @user[:password] = 'password'
-        assert_not @user.valid?
-        assert_equal "Password must include at least one lowercase letter, one uppercase letter, and one digit. Forbidden words include DCAF and password.",
-                     @user.errors.messages[:password].first
+    it 'should require a complex password' do
+      @user.password = 'password'
+      @user.password_confirmation = 'password'
+      assert_not @user.valid?
+      assert_equal 'Password must include at least one lowercase letter, ' \
+                   'one uppercase letter, and one digit. Forbidden words ' \
+                   'include DCAF and password.',
+                   @user.errors.messages[:password].first
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Picks up the clutch work done by @mccabe615 in #478 -- mostly just making test adjustments to his work.

This pull request makes the following changes: 
* Adds validation to require complex password (8 char min, cap letter, letter, no word 'password' or 'dcaf')
* Adjusts everything downwind of that, such as tests, seeds, etc

It relates to the following issue #s: 
* Fixes #389 
