### PR TITLE
add assets precompile to circle build deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,11 @@ machine:
 deployment:
   staging:
     branch: master
-    heroku:
-      appname: dcaf-cmapp-staging
+    commands:
+      - bundle exec rake assets:clobber assets:precompile
+      - git push git@heroku.com:dcaf-cmapp-staging.git $CIRCLE_SHA1:master
+    # heroku:
+      # appname: dcaf-cmapp-staging
 
 test:
   post:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

As part of the build succeeding, this precompiles assets and then pushes that. Should solve the problem of bootstrap-sass using absolute urls when compiling assets, thus leading to cross site requests to the staging environment in production, thus...

This pull request makes the following changes:
* Precompiles assets on job success, then pushes to heroku staging

It relates to the following issue #s: 
* Fixes #508 (I hope)

