### PR TITLE
Wait for ajax in integration tests

### DIFF
--- a/test/integration/logging_calls_test.rb
+++ b/test/integration/logging_calls_test.rb
@@ -42,7 +42,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       visit edit_pregnancy_path @pregnancy
       wait_for_page_to_load
       find('a', text: 'Call Log').click
-      wait_for_section_to_load 'call_log'
+      wait_for_ajax
 
       within :css, '#call_log' do
         assert has_text? @timestamp.display_date
@@ -67,7 +67,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
       visit edit_pregnancy_path @pregnancy
       wait_for_page_to_load
       find('a', text: 'Call Log').click
-      wait_for_section_to_load 'call_log'
+      wait_for_ajax
 
       within :css, '#call_log' do
         assert has_content? 'Reached patient', count: 3
@@ -102,7 +102,7 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
         visit edit_pregnancy_path @pregnancy
         wait_for_page_to_load
         find('a', text: 'Call Log').click
-        wait_for_section_to_load 'call_log'
+        wait_for_ajax
 
         within :css, '#call_log' do
           assert has_text? @timestamp.display_date
@@ -118,9 +118,5 @@ class LoggingCallsTest < ActionDispatch::IntegrationTest
 
   def wait_for_page_to_load
     has_text? 'Submit pledge'
-  end
-
-  def wait_for_section_to_load(section)
-    find("##{section}")
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -92,7 +92,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_referred_by').select 'Other abortion fund'
       fill_in 'Special circumstances', with: 'Stuff'
 
-      click_away_from_field
+      wait_for_ajax
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end
@@ -128,5 +128,6 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
   def click_away_from_field
     fill_in 'First and last name', with: nil
+    wait_for_ajax
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -92,7 +92,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       find('#pregnancy_referred_by').select 'Other abortion fund'
       fill_in 'Special circumstances', with: 'Stuff'
 
-      wait_for_ajax
+      click_away_from_field
       visit authenticated_root_path
       visit edit_pregnancy_path @pregnancy
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,15 @@ class ActionDispatch::IntegrationTest
   def sign_out
     click_link 'Sign out'
   end
+
+  def wait_for_ajax
+    counter = 0
+    while page.execute_script('return $.active').to_i > 0
+      counter += 1
+      sleep(0.1)
+      raise 'Ajax request took longer than 5 seconds, failing' if counter >= 50
+    end
+  end
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Finally googled the magic words - adds a method to wait for ajax calls to complete before moving on.

This pull request makes the following changes:
* Adds a `wait_for_ajax` method to the test helper
* Some edits to integration tests that screw up all the time

It relates to the following issue #s: 
* Fixes #446 
