### PR TITLE
Makes Pregnancy#line an enum

### DIFF
--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -33,7 +33,7 @@ class Pregnancy
   field :last_menstrual_period_weeks, type: Integer
   field :last_menstrual_period_days, type: Integer
   enum :voicemail_preference, [:not_specified, :no, :yes]
-  field :line, type: String # DC, MD, VA
+  enum :line, [:DC, :MD, :VA]
   field :spanish, type: Boolean
   field :appointment_date, type: Date
   field :urgent_flag, type: Boolean

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -41,7 +41,7 @@ class Pregnancy
   # General patient information
   field :age, type: Integer
   field :city, type: String
-  field :state, type: String # ennumeration?
+  field :state, type: String
   field :zip, type: String
   field :county, type: String
   field :race_ethnicity, type: String
@@ -51,7 +51,7 @@ class Pregnancy
   field :insurance, type: String
   field :income, type: String
   field :referred_by, type: String
-  field :special_circumstances, type: String # ennumeration
+  field :special_circumstances, type: String # TODO change to a has_many through
 
   # Procedure result - generally for administrative use
   field :fax_received, type: Boolean

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -40,7 +40,7 @@ class PregnancyTest < ActiveSupport::TestCase
       it 'should return a pledge_identifier' do
         @pregnancy.line = 'DC'
         @pregnancy.patient.update primary_phone: '111-333-5555'
-        # assert_equal 'D3-5555', @pregnancy.pledge_identifier # make it live after merging that one PR
+        assert_equal 'D3-5555', @pregnancy.pledge_identifier # make it live after merging that one PR
       end
     end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns line into an enum. In effect, this hardcodes everyone into the DC line for the time being.

This pull request makes the following changes:
* does what it says on the label

It relates to the following issue #s: 
* Fixes #578 
