### PR TITLE
Single pregnancy

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,10 +6,10 @@ class DashboardsController < ApplicationController
   def search
     patients = Patient.search params[:search]
     @results = []
-    patients.each { |patient| @results << patient.pregnancies.most_recent }
+    patients.each { |patient| @results << patient.pregnancy }
 
     patient = Patient.new
-    @pregnancy = patient.pregnancies.new
+    @pregnancy = patient.build_pregnancy
     @today = Time.zone.today.to_date
     @phone = searched_for_phone?(params[:search]) ? params[:search] : ''
     @name = searched_for_name?(params[:search]) ? params[:search] : ''

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -7,7 +7,7 @@ class Patient
   before_validation :clean_fields
 
   # Relationships
-  has_many :pregnancies
+  has_one :pregnancy
 
   # Fields
   field :name, type: String # strip

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ Patient.all.each do |patient|
                     created_by: user2
                   }
 
-  pregnancy = patient.pregnancies.create creation_hash
+  pregnancy = patient.pregnancy.create creation_hash
 
   # Create calls for pregnancy
   5.times do
@@ -61,11 +61,11 @@ Patient.find_by(name: 'Patient 2')
                      created_by: user2
 
 # Adds Patients 0 thru 4 to regular call list
-user.add_pregnancy Patient.find_by(name: 'Patient 0').pregnancies.first
-user.add_pregnancy Patient.find_by(name: 'Patient 1').pregnancies.first
-user.add_pregnancy Patient.find_by(name: 'Patient 2').pregnancies.first
-user.add_pregnancy Patient.find_by(name: 'Patient 3').pregnancies.first
-user.add_pregnancy Patient.find_by(name: 'Patient 4').pregnancies.first
+user.add_pregnancy Patient.find_by(name: 'Patient 0').pregnancy
+user.add_pregnancy Patient.find_by(name: 'Patient 1').pregnancy
+user.add_pregnancy Patient.find_by(name: 'Patient 2').pregnancy
+user.add_pregnancy Patient.find_by(name: 'Patient 3').pregnancy
+user.add_pregnancy Patient.find_by(name: 'Patient 4').pregnancy
 
 # Add Patient 5 to completed calls list
 patient_in_completed_calls = Patient.find_by(name: 'Patient 5')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,8 @@ Patient.all.each do |patient|
                     created_by: user2
                   }
 
-  pregnancy = patient.pregnancy.create creation_hash
+  pregnancy = patient.build_pregnancy(creation_hash)
+  pregnancy.save
 
   # Create calls for pregnancy
   5.times do
@@ -56,7 +57,7 @@ end
 # Add a note to Patient 2
 note_text = 'This is a note ' * 10
 Patient.find_by(name: 'Patient 2')
-       .pregnancies.first
+       .pregnancy
        .notes.create full_text: note_text,
                      created_by: user2
 
@@ -69,7 +70,7 @@ user.add_pregnancy Patient.find_by(name: 'Patient 4').pregnancy
 
 # Add Patient 5 to completed calls list
 patient_in_completed_calls = Patient.find_by(name: 'Patient 5')
-                                    .pregnancies.first
+                                    .pregnancy
 user.add_pregnancy patient_in_completed_calls
 patient_in_completed_calls.calls.create status: 'Left voicemail',
                                         created_by: user

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -9,7 +9,7 @@ class PregnancyTest < ActiveSupport::TestCase
     [@pt_1, @pt_2, @pt_3].each do |pt|
       create :pregnancy, patient: pt, created_by: @user
     end
-    @pregnancy = @pt_1.pregnancies.first
+    @pregnancy = @pt_1.pregnancy
   end
 
   describe 'validations' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

TLDR: Patient-has-many-pregnancies as a way of keeping track of patients who come back is much more of a huge pain than it's worth, so this punts on a whole class of validation and data storage problems in favor of simplicity. We can fix any reporting duplication with group bys, like god intended.

We should take advantage of this in a few other ways, like changing the has to an embed and fixing the routing, in a separate PR. 

BIG s/o to my dog integration tests for confirming that everything still works after this change!

This pull request makes the following changes:
* Converts `Patient has many pregnancies` into a `patient has one pregnancy` 
* Fixes tests and seedfile

It relates to the following issue #s: 
* Fixes #595 
* Bumps #Y
