### PR TITLE
change default mail from addresses

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 # app/mailers/user_mailer.rb
 class UserMailer < Devise::Mailer
-  default from: 'no-reply@dcaf.org'
+  default from: 'no-reply@dcabortionfund.org'
 
   def password_changed(id)
     @user = User.find(id)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'noreply@example.com'
+  config.mailer_sender = 'no-reply@dcabortionfund.org'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -6,6 +6,6 @@ class UserMailerTest < ActionMailer::TestCase
     mail = UserMailer.password_changed(@user.id)
     assert_equal 'Your password has changed', mail.subject
     assert_equal [@user.email], mail.to
-    assert_equal ['no-reply@dcaf.org'], mail.from
+    assert_equal ['no-reply@dcabortionfund.org'], mail.from
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

change defaults "from"

This pull request makes the following changes:
* devise.rb
* user_mailer.rb

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #607 

