### PR TITLE
Include .errors hash in flash msg

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -12,7 +12,7 @@ class PatientsController < ApplicationController
     if patient.save
       flash[:notice] = 'A new patient has been successfully saved'
     else
-      flash[:alert] = 'An error prevented this patient from being saved'
+      flash[:alert] = "Errors prevented this patient from being saved: #{patient.errors.full_messages.to_sentence}"
     end
     current_user.add_patient patient
     redirect_to root_path


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:

As suggested by @Kevin-Wei:

“update the flash msg to use the .errors hash in the create action on the patient's controller”

It relates to the following issue #s: 

* Fixes #605



