### PR TITLE
prevent cleanup task from choking on find each

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -85,7 +85,7 @@ class Patient
   end
 
   def self.trim_urgent_patients
-    Patient.all.find_each do |patient|
+    Patient.all do |patient|
       unless patient.still_urgent?
         patient.urgent_flag = false
         patient.save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,6 +48,12 @@ Patient.all.each do |patient|
                             created_by: user2
     end
   end
+
+  if patient.name == 'Patient 1'
+    patient.calls.create! status: 'Reached patient',
+                          created_at: 14.hours.ago,
+                          created_by: user
+  end
 end
 
 # Add a note to Patient 2


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fixes an issue that was causing `Patient.trim_urgent_patients` (and thus the rake `nightly_cleanup` task) to choke. 

This pull request makes the following changes:
* Strips a `find_each` from `Patient.trim_urgent_patients`
* Adds an example case of someone who's getting removed from the call list with the rake task to seedfile

It relates to the following issue #s: 
* Fixes #609