### PR TITLE
add db indices to patient model

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -51,6 +51,13 @@ class Patient
   field :urgent_flag, type: Boolean
   field :special_circumstances, type: Array, default: []
 
+  #Indices
+  index({ primary_phone: 1 }, { unique: true })
+  index({ other_contact_phone: 1 })
+  index({ name: 1 })
+  index({ other_contact: 1 })
+  index({ urgent_flag: 1 })
+
   # Validations
   validates :name,
             :primary_phone,


### PR DESCRIPTION
Investigate MongoDB indexing #645

This pull request makes the following changes:
* add indices to patient
* run rake db:mongoid:create_indexes


Fixes #645 