### PR TITLE
Mark Patient Not Urgent if Resolved or Pledge Sent

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -130,6 +130,7 @@ class Patient
   def still_urgent?
     # Verify that a pregnancy has not been marked urgent in the past six days
     return false if recent_history_tracks.count == 0
+    return false if pregnancy.pledge_sent || pregnancy.resolved_without_dcaf
     recent_history_tracks.sort.reverse.each do |history|
       return true if history.marked_urgent?
     end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -210,5 +210,32 @@ class PatientTest < ActiveSupport::TestCase
         # TODO: TEST patient#trim_urgent_pregnancies
       end
     end
+
+    describe 'still urgent method' do
+      it 'should return true if marked urgent in last 6 days' do
+        @patient.update urgent_flag: true
+        assert @patient.still_urgent?
+      end
+
+      it 'should return false if pledge sent' do
+        @patient.update urgent_flag: true
+        @pregnancy.update pledge_sent: true
+        assert_not @patient.still_urgent?
+      end
+
+      it 'should return false if resolved without dcaf' do
+        @patient.update urgent_flag: true
+        @pregnancy.update resolved_without_dcaf: true
+        assert_not @patient.still_urgent?
+      end
+
+      it 'should return false if not updated for more than 6 days' do
+        Timecop.freeze(Time.zone.now - 7.days) do
+          @patient.update urgent_flag: true
+        end
+
+        assert_not @patient.still_urgent?
+      end
+    end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

First time looking at this awesome project. Please let me know if there is anything I should do differently!

No longer considers a patient urgent is they are marked as resolved without dcaf or if a pledge is sent. 

This pull request makes the following changes:
* In `Patient#still_urgent?` method, returns false if `Pregnancy#resolved_without_dcaf` or `Pregnancy#pledge_sent` is true
* Added tests for the patient model to test the `still_urgent?` method. 

It relates to the following issue #s: 
* fixes #655 
