### PR TITLE
Create a rake task for updating user role data from string to integer

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,21 @@
+namespace :user do
+  desc "update role field production data"
+  task update_role: :environment do
+    User.all.each do |user|
+      enum_role = check_role(user.role)
+      user.update(role: enum_role)
+    end
+
+    puts 'User role updated'
+  end
+
+private
+  def check_role(role)
+    case role
+    when 'admin'
+      1
+    else
+      0
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I created a rake task for updating User role data from String to Integer. In order to change the role field totally you just need to run the rake task first which is `rake user:update_role` then after that change the field role type to Integer.

This pull request makes the following changes:
* User model role field data

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #533 

