### PR TITLE
Admin Create New Users

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -31,6 +31,11 @@ $font-size: 17px;
   font-size: $font-size;
 }
 
+.form-error {
+  color: red;
+  font-size: 14px;
+}
+
 .btn-primary {
   @extend .btn-primary;
   background-color: $dcaf-color;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
 
   def new
     unless current_user.admin?
-      render text: 'Permission Denied', status: :unauthorized
+      redirect_to root_path
       return
     end
     @user = User.new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,2 @@
 module ApplicationHelper
-  # helper method to display form validation errors
-  # see /users/new for examples
-  def error_message(obj, field)
-    return if obj.errors[field].empty?
-    str = ''
-    obj.errors[field].each do |error|
-      str += "<span class='form-error'>#{field.to_s.humanize} #{error}</span><br/>"
-    end
-    str.html_safe
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  # helper method to display form validation errors
+  # see /users/new for examples
+  def error_message(obj, field)
+    return if obj.errors[field].empty?
+    str = ''
+    obj.errors[field].each do |error|
+      str += "<span class='form-error'>#{field.to_s.humanize} #{error}</span><br/>"
+    end
+    str.html_safe
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,7 @@ class User
   field :locked_at,       type: Time
 
   # Validations
+  # email presence validated through Devise
   validates :name, presence: true
   validate :secure_password
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 # Fields are all devise settings; most of the methods relate to call list mgmt.
 class User
   include Mongoid::Document
+  include Mongoid::Enum
   include Mongoid::Userstamp::User
 
   # Devise modules
@@ -25,7 +26,7 @@ class User
   # Non-devise generated
   field :name, type: String
   field :line, type: String
-  field :role, type: String
+  enum :role, [:cm, :admin]
   field :call_order, type: Array
 
   ## Database authenticatable
@@ -58,7 +59,7 @@ class User
   field :locked_at,       type: Time
 
   # Validations
-  validates :email, :name, presence: true
+  validates :name, presence: true
   validate :secure_password
 
   def secure_password
@@ -113,6 +114,10 @@ class User
       # TODO: reexamine this behavior in awhile
       patients.delete(p) if recently_reached_by_user?(p)
     end
+  end
+
+  def admin?
+    role == :admin
   end
 
   private

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -6,7 +6,7 @@
       <li><%= link_to 'Dashboard', authenticated_root_path %></li>
     <% end %>
     <% if current_user.admin? %>
-      <li> <%= link_to 'Create User', new_user_url %></li>
+      <li> <%= link_to 'Create User', new_user_path %></li>
     <% end %>
     <li><%= link_to current_user.name, edit_user_registration_path %></li>
     <li><%= link_to 'Sign out', destroy_user_session_path, method: 'delete' %></li>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -5,6 +5,9 @@
     <% unless current_page?(authenticated_root_url) %>
       <li><%= link_to 'Dashboard', authenticated_root_path %></li>
     <% end %>
+    <% if current_user.admin? %>
+      <li> <%= link_to 'Create User', new_user_url %></li>
+    <% end %>
     <li><%= link_to current_user.name, edit_user_registration_path %></li>
     <li><%= link_to 'Sign out', destroy_user_session_path, method: 'delete' %></li>
   <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,28 @@
+<div class='authform'>
+  <h3>Create User</h3>
+    <%= form_for @user do |f| %>
+      <div class='form-group'>
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 'form-control', autofocus: true %>
+        <%= error_message(@user, 'email') %>
+      </div>
+      <div class='form-group'>
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control' %>
+        <%= error_message(@user, 'name') %>
+      </div>
+      <div class='form-group'>
+        <%= f.label :password %>
+        <%= f.password_field :password, autocomplete: 'off', label: "Password (#{@minimum_password_length || 8} characters minimum)", class: 'form-control' %>
+        <%= error_message(@user, 'password') %>
+      </div>
+      <div class='form-group'>
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control' %>
+        <%= error_message(@user, 'password_confirmation') %>
+      </div>
+      <div class='form-group'>
+        <%= f.submit "Add", class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,27 +1,10 @@
 <div class='authform'>
   <h3>Create User</h3>
-    <%= form_for @user do |f| %>
-      <div class='form-group'>
-        <%= f.label :email %>
-        <%= f.email_field :email, class: 'form-control', autofocus: true %>
-        <%= error_message(@user, 'email') %>
-      </div>
-      <div class='form-group'>
-        <%= f.label :name %>
-        <%= f.text_field :name, class: 'form-control' %>
-        <%= error_message(@user, 'name') %>
-      </div>
-      <div class='form-group'>
-        <%= f.label :password %>
-        <%= f.password_field :password, autocomplete: 'off', label: "Password (#{@minimum_password_length || 8} characters minimum)", class: 'form-control' %>
-        <%= error_message(@user, 'password') %>
-      </div>
-      <div class='form-group'>
-        <%= f.label :password_confirmation %>
-        <%= f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control' %>
-        <%= error_message(@user, 'password_confirmation') %>
-      </div>
-      <div class='form-group'>
+    <%= bootstrap_form_for @user do |f| %>
+        <%= f.email_field :email %>
+        <%= f.text_field :name %>
+        <%= f.password_field :password, autocomplete: 'off', label: "Password (#{@minimum_password_length || 8} characters minimum)"%>
+        <%= f.password_field :password_confirmation, autocomplete: 'off'%>
         <%= f.submit "Add", class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
- 
+
   authenticate :user do
     root to: 'dashboards#index', as: :authenticated_root
     get 'dashboard', to: 'dashboards#index', as: 'dashboard'
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     patch 'users/reorder_call_list', to: 'users#reorder_call_list', as: 'reorder_call_list', defaults: { format: :js }
   end
   root :to => redirect('/users/sign_in')
+  resources :users, only: [:new, :create]
   devise_for :users, skip: [:registrations]
   as :user do
     get '/users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get 'dashboard', to: 'dashboards#index', as: 'dashboard'
     get  'report', to: 'reports#index', as: 'report'
     post 'search', to: 'dashboards#search', defaults: { format: :js }
+    resources :users, only: [:new, :create]
     resources :patients, only: [ :create, :edit, :update ] do
       resources :calls, only: [ :create ]
       resources :notes, only: [ :create, :update ]
@@ -15,7 +16,6 @@ Rails.application.routes.draw do
     patch 'users/reorder_call_list', to: 'users#reorder_call_list', as: 'reorder_call_list', defaults: { format: :js }
   end
   root :to => redirect('/users/sign_in')
-  resources :users, only: [:new, :create]
   devise_for :users, skip: [:registrations]
   as :user do
     get '/users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -10,6 +10,16 @@ class UsersControllerTest < ActionController::TestCase
     create :pregnancy, patient: @patient_2
   end
 
+  describe 'create method' do
+    it 'should raise if user is not admin' do
+      @user.role = :cm
+      @user.save!
+      assert_raise RuntimeError, 'Permission Denied' do
+        post :create
+      end
+    end
+  end
+
   describe 'add_patient method' do
     before do
       patch :add_patient, id: @patient_1, user_id: @user, format: :js

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class CreateUserTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+  end
+
+  after do
+    Capybara.use_default_driver
+  end
+
+  describe 'admin user' do
+    before do
+      @user = create :user, role: :admin
+      log_in_as @user
+    end
+
+    it 'should be able to create user' do
+      assert_difference('User.count', 1) do
+        assert_text 'Create User'
+        click_link 'Create User'
+
+        assert has_field? 'Email'
+        fill_in 'Email', with: 'test@test.com'
+
+        assert has_field? 'Name'
+        fill_in 'Name', with: 'Test User'
+
+        assert has_field? 'Password'
+        fill_in 'Password', with: 'FCZCidQP4C8GTz'
+
+        assert has_field? 'Password confirmation'
+        fill_in 'Password confirmation', with: 'FCZCidQP4C8GTz'
+
+        click_button 'Add'
+      end
+
+      user = User.find_by(email: 'test@test.com')
+      assert_not_nil user
+      assert_equal user.name, 'Test User'
+    end
+
+    it 'should validate form correctly' do
+      visit new_user_path
+      click_button 'Add'
+
+      assert_text "Email can't be blank"
+      assert_text "Name can't be blank"
+      assert_text "Password can't be blank"
+
+      fill_in 'Email', with: 'test@test'
+      fill_in 'Password', with: 'asdfasdf'
+      click_button 'Add'
+
+      assert_text 'Email is invalid'
+      assert_text 'must include at least one lowercase letter, one uppercase '\
+                  'letter, and one digit.'
+      assert_text "Password confirmation doesn't match Password"
+    end
+  end
+
+  describe 'non admin user' do
+    before do
+      @user = create :user, role: :cm
+      log_in_as @user
+    end
+
+    it 'should not show add user button' do
+      assert_no_text 'Create User'
+    end
+
+    it 'should raise if navigate to form' do
+      assert_not @user.admin?
+      visit new_user_path
+      assert_equal 'Permission Denied', page.text
+    end
+  end
+
+  describe 'not logged in' do
+    it 'should show nothing if not logged in' do
+      visit new_user_path
+      assert_equal current_path, new_user_session_path
+    end
+  end
+end

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -27,7 +27,7 @@ class CreateUserTest < ActionDispatch::IntegrationTest
         fill_in 'Name', with: 'Test User'
 
         assert has_field? 'Password'
-        fill_in 'Password', with: 'FCZCidQP4C8GTz'
+        fill_in 'Password', with: 'FCZCidQP4C8GTz', match: :prefer_exact
 
         assert has_field? 'Password confirmation'
         fill_in 'Password confirmation', with: 'FCZCidQP4C8GTz'
@@ -44,18 +44,16 @@ class CreateUserTest < ActionDispatch::IntegrationTest
       visit new_user_path
       click_button 'Add'
 
-      assert_text "Email can't be blank"
-      assert_text "Name can't be blank"
-      assert_text "Password can't be blank"
+      assert_text "can't be blank"
 
       fill_in 'Email', with: 'test@test'
-      fill_in 'Password', with: 'asdfasdf'
+      fill_in 'Password', with: 'asdfasdf', match: :prefer_exact
       click_button 'Add'
 
-      assert_text 'Email is invalid'
+      assert_text 'is invalid'
       assert_text 'must include at least one lowercase letter, one uppercase '\
                   'letter, and one digit.'
-      assert_text "Password confirmation doesn't match Password"
+      assert_text "doesn't match Password"
     end
   end
 
@@ -69,10 +67,10 @@ class CreateUserTest < ActionDispatch::IntegrationTest
       assert_no_text 'Create User'
     end
 
-    it 'should raise if navigate to form' do
+    it 'should redirect to root path if navigate to form' do
       assert_not @user.admin?
       visit new_user_path
-      assert_equal 'Permission Denied', page.text
+      assert_equal current_path, root_path
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Allows admins to create new users.

This pull request makes the following changes:
* Changes the `User#role` to `enum`. I don't know if the current `role` is being utilized at all so I wasn't sure if creating a data migration task was necessary to populate the enum value. 
* Added a 'Created User' link to the Navigation Links only visible to admins
* Created a new user form. It was suggested to do it with Devise. After some research it seems like to me Devise doesn't handle this well since it is designed for people to create their own accounts.
* It was also suggested to use Pundit to ensure only admins can create users. It seemed simpler and just as effective to simply check if the `current_user` is an admin in the controller methods and views. 
* Added integration and controller tests to ensure only admins can create users

This PR has a lot of changes and a few assumptions made. Let me know if anything seems wrong or strange and I will be happy to fix it.

It relates to the following issue #s: 
* Fixes #649 
