### PR TITLE
Add PT's appointment date in the dashboard information

### DIFF
--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -12,6 +12,7 @@
         <th>Name</th>
         <th>LMP</th>
         <th>Status</th>
+        <th>Appointment date</th>
         <th>Notes</th>
         <th></th>
         <th></th>
@@ -27,6 +28,7 @@
           <td><%= link_to patient.name, edit_patient_path(patient) %></td>
           <td><%= patient.pregnancy.last_menstrual_period_display_short %></td>
           <td><%= patient.status %></td>
+          <td><%= patient.appointment_date %></td>
           <td><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
 
           <% if table_type == 'completed_calls' || table_type == 'urgent_patients' %>

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class DashboardTest < ActionDispatch::IntegrationTest
+  before do
+    @user = create :user
+    @patient = create(:patient, initial_call_date: 3.days.ago, appointment_date: '2017-02-01', urgent_flag: true, created_by: @user)
+    pregnancy = @patient.build_pregnancy(last_menstrual_period_weeks: 6, last_menstrual_period_days: 3, created_by: @user)
+    pregnancy.save
+
+    @patient.calls.create!(status: 'Left voicemail', created_at: 3.days.ago, updated_at: 3.days.ago, created_by: @user)
+
+    @user.add_patient @patient
+
+    log_in_as @user
+  end
+
+  describe 'visiting the dashboard' do
+    it 'Table with user\'s call list should display appointment date field' do
+      assert page.find_by_id('call_list').has_content? 'Appointment date'
+      assert page.find_by_id('call_list').has_content? @patient.appointment_date
+    end
+
+    it 'Table with user\'s completed calls should display appointment date field' do
+      assert page.find_by_id('completed_calls').has_content? 'Appointment date'
+      refute page.find_by_id('completed_calls').has_content? @patient.appointment_date
+    end
+
+    it 'Table with urgent cases should display appointment date field' do
+      assert page.find_by_id('urgent_patients').has_content? 'Appointment date'
+      assert page.find_by_id('urgent_patients').has_content? @patient.appointment_date
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes the following changes:
* Add appointment date information to dashboard: call list, completed calls and urgent cases.
(with integration test)

It relates to the following issue #s: 
* #629 

![schermata 2016-10-16 alle 02 24 42](https://cloud.githubusercontent.com/assets/3228071/19414290/fbd3938e-9347-11e6-830e-8552f4351183.png)

