### PR TITLE
Add Content Security Policy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,6 @@ class ApplicationController < ActionController::Base
 
   # Add CSP
   def security_headers
-    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc='; font-src 'self' fonts.gstatic.com; style-src 'self' 'sha256-wkY2X5hecQzbhnFCqvTpwrUJ1f4X8LH5WFjYUzv1wmU='; object-src;"
+    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline'; object-src; report-uri https://fdb0d6ba398e6ae4b6f8d2f82e773464.report-uri.io/r/default/csp/reportOnly"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,6 @@ class ApplicationController < ActionController::Base
 
   # Add CSP
   def security_headers
-    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self' www.google-analytics.com; font-src 'self' fonts.gstatic.com; style-src 'self' sha256-wkY2X5hecQzbhnFCqvTpwrUJ1f4X8LH5WFjYUzv1wmU=; object-src;"
+    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc='; font-src 'self' fonts.gstatic.com; style-src 'self' 'sha256-wkY2X5hecQzbhnFCqvTpwrUJ1f4X8LH5WFjYUzv1wmU='; object-src;"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers, unless: :devise_controller?
   before_action :authenticate_user!
+  before_action :security_headers
 
   # whitelists attributes in devise
   def configure_permitted_parameters
@@ -23,5 +24,10 @@ class ApplicationController < ActionController::Base
     response.headers['Cache-Control'] = 'no-cache, no-store'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+
+  # Add CSP
+  def security_headers
+    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self' www.google-analytics.com; font-src 'self' fonts.gstatic.com; style-src 'self' sha256-wkY2X5hecQzbhnFCqvTpwrUJ1f4X8LH5WFjYUzv1wmU=; object-src;"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers, unless: :devise_controller?
   before_action :authenticate_user!
-  before_action :security_headers
+  before_action :csp_headers
 
   # whitelists attributes in devise
   def configure_permitted_parameters
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Add CSP
-  def security_headers
+  def csp_headers
     response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline'; object-src; report-uri https://fdb0d6ba398e6ae4b6f8d2f82e773464.report-uri.io/r/default/csp/reportOnly"
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR adds content security policy (CSP). CSP is a powerful standard that limits what content will be allowed in the browser by a policy sent in a HTTP header. The purpose is to prevent content injection such as cross-site scripting. CSP will prevent execution of injection content. The current policy is in report only mode which will not block content but report it to a collector.

You can read more here: https://content-security-policy.com/

Breakdown of the policy:

"default-src 'self';  - **set the default policy as self only. allows content/media from hosting domain**

script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; - **allows javascript from hosting domain, google analytics. CSP allows whitelisting inline script with a hash of the Javascript the hash is one such hash. unfortunetly we have to allow unsafe-eval due to jquery using eval in it's code. this is an area to improve as this may open up holes for xss**

font-src 'self' fonts.gstatic.com; - **whitelist hosting domain and google fonts for fonts**

style-src 'self' 'unsafe-inline'; **whitelist hosting domain and due to a browser bug inline css**

object-src; - **do not allow other media**

report-uri https://fdb0d6ba398e6ae4b6f8d2f82e773464.report-uri.io/r/default/csp/reportOnly" - **URI for reporting violations. currently using my account on report URI. I would suggest changing this to a DCAF account.**

This pull request makes the following changes:
* add csp_header before filter
* set initial policy

