### PR TITLE
Clear Call List After No Login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,8 @@ class User
   validates :email, :name, presence: true
   validate :secure_password
 
+  TIME_BEFORE_INACTIVE = 2.weeks
+
   def secure_password
     return true if password.nil?
     pc = verify_password_complexity
@@ -109,9 +111,14 @@ class User
   end
 
   def clear_call_list
-    patients.each do |p|
-      # TODO: reexamine this behavior in awhile
-      patients.delete(p) if recently_reached_by_user?(p)
+    if last_sign_in_at.present? &&
+       last_sign_in_at < Time.zone.now - TIME_BEFORE_INACTIVE
+      patients.clear
+    else
+      patients.each do |p|
+        # TODO: reexamine this behavior in awhile
+        patients.delete(p) if recently_reached_by_user?(p)
+      end
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,6 +74,23 @@ class UserTest < ActiveSupport::TestCase
       @user.clear_call_list
       assert_equal 1, @user.recently_called_patients.count
     end
+
+    it 'should clear patient list when user has not logged in' do
+      assert_not @user.patients.empty?
+      last_sign_in = Time.zone.now - User::TIME_BEFORE_INACTIVE - 1.day
+      @user.last_sign_in_at = last_sign_in
+      @user.clear_call_list
+
+      assert @user.patients.empty?
+    end
+
+    it 'should not clear patient list if signed in before time' do
+      assert_not @user.patients.empty?
+      @user.last_sign_in_at = Time.zone.now
+      @user.clear_call_list
+
+      assert_not @user.patients.empty?
+    end
   end
 
   describe 'patient methods' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -84,7 +84,7 @@ class UserTest < ActiveSupport::TestCase
       assert @user.patients.empty?
     end
 
-    it 'should not clear patient list if signed in before time' do
+    it 'should not clear patient list if user signed in recently' do
       assert_not @user.patients.empty?
       @user.last_sign_in_at = Time.zone.now
       @user.clear_call_list


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Clears user's call list if they don't sign in for _2 weeks_

This pull request makes the following changes:
* Adds constant `TIME_BEFORE_INACTIVE` to `User` model
* Inside `User#clear_call_list` clears patient list if `User#last_sign_in_at` is 2 weeks or longer
* Test new code in the user model test file

It relates to the following issue #s: 
* Fixes #666 
