### PR TITLE
added (others) option to patient insurance

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -22,7 +22,7 @@ module PatientsHelper
     [nil, 'DC Medicaid', 'MD MCHIP',
      'MD Medical Assistance for Families (MA4F)', 'VA Medicaid/CHIP',
      'Other state Medicaid', 'Private or employer-sponsored health insurance',
-     'No insurance', "Don't know"]
+     'No insurance', "Don't know", "Other (add to notes)"]
   end
 
   def income_options

--- a/app/views/dashboards/search.js.erb
+++ b/app/views/dashboards/search.js.erb
@@ -1,6 +1,6 @@
 $('#search_results_shell').empty();
-<% if @results.blank? %>
-  $("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
-<% else %>
+$("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
+<% if @results.any? %>
+  $("#search_results_shell").append("<div class='row m-t'></div>");
   $("#search_results_shell").append("<%= escape_javascript(render partial: 'dashboards/table_content', locals: { title: 'Search results', table_type: 'search_results', patients: @results } ) %>");
 <% end %>

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -1,4 +1,8 @@
-<h3><small>Your search produced no results, so add a new patient:</small></h3>
+<% if @results.empty? %>
+  <h3><small>Your search produced no results, so add a new patient:</small></h3>
+<% else %>
+  <h3><small>Add a new patient:</small></h3>
+<% end %>
 
 <%= bootstrap_form_for patient do |f| %>
   <div class="col-sm-2">

--- a/test/integration/record_lookup_test.rb
+++ b/test/integration/record_lookup_test.rb
@@ -58,6 +58,14 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
       assert has_text? 'Search results'
       assert has_text? 'Susan Everyteen'
     end
+
+    it 'should display new pregnancy partial even for the search results' do
+      fill_in 'search', with: 'susan everyteen'
+      click_button 'Search'
+
+      assert has_text? 'Add a new patient'
+      assert has_text? 'Search results'
+    end
   end
 
   describe 'looking for someone who does not exist', js: true do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Added 'Other (add to notes)' option to patient insurance for the patient information.

It relates to the following issue #s: Fixes #680 
![screenshot from 2016-10-19 12 22 59](https://cloud.githubusercontent.com/assets/219658/19508422/d8176838-95f6-11e6-98f9-ecb6ef35fbcd.png)


