### PR TITLE
enabled patient partial regaradless to search results

### DIFF
--- a/app/views/dashboards/search.js.erb
+++ b/app/views/dashboards/search.js.erb
@@ -1,6 +1,6 @@
 $('#search_results_shell').empty();
-<% if @results.blank? %>
-  $("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
-<% else %>
+$("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
+<% if @results.any? %>
+  $("#search_results_shell").append("<div class='row m-t'></div>");
   $("#search_results_shell").append("<%= escape_javascript(render partial: 'dashboards/table_content', locals: { title: 'Search results', table_type: 'search_results', patients: @results } ) %>");
 <% end %>

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -1,4 +1,8 @@
-<h3><small>Your search produced no results, so add a new patient:</small></h3>
+<% if @results.empty? %>
+  <h3><small>Your search produced no results, so add a new patient:</small></h3>
+<% else %>
+  <h3><small>Add a new patient:</small></h3>
+<% end %>
 
 <%= bootstrap_form_for patient do |f| %>
   <div class="col-sm-2">

--- a/test/integration/record_lookup_test.rb
+++ b/test/integration/record_lookup_test.rb
@@ -58,6 +58,15 @@ class RecordLookupTest < ActionDispatch::IntegrationTest
       assert has_text? 'Search results'
       assert has_text? 'Susan Everyteen'
     end
+
+    it 'should display new pregnancy partial even for the search results' do
+      fill_in 'search', with: 'susan everyteen'
+      click_button 'Search'
+
+      assert has_text? 'Add a new patient'
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
+    end
   end
 
   describe 'looking for someone who does not exist', js: true do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
  New patient partial should display as the result of a search regardless of whether it returns results
* changes in `dashboard/search.js.erb` to display partial regardless to search results
* added test case to this change in `integration/record_lookup_test.rb`
* changes of search results page text in `_new_patient_html.erb`

It relates to the following issue #s: bumps #675 
Fixes #702

![screenshot from 2016-10-19 17 37 56](https://cloud.githubusercontent.com/assets/219658/19518133/19e6397a-9623-11e6-84ac-6a7764795b82.png)


