### PR TITLE
Line Select View Draft

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -15,6 +15,9 @@ class DashboardsController < ApplicationController
     respond_to { |format| format.js }
   end
 
+  def lineselect
+  end
+
   private
 
   def searched_for_phone?(query)

--- a/app/views/dashboards/lineselect.html.erb
+++ b/app/views/dashboards/lineselect.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="col-sm-12">
+    <h1 class="border-bottom title">Welcome to DCAF Case Manager!</h1>
+    <h4>What line are you working tonight?</h4>
+        <form>
+          <input type="radio" name="call_line" value="dc_line"> DC Line </input><br/>
+          <input type="radio" name="call_line" value="va_line"> VA Line </input><br/>
+          <input type="radio" name="call_line" value="md_line"> MD Line </input><br/><br/>
+
+          <input class="btn-lg btn-primary" type="submit" value="Start">
+        </form>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     root to: 'dashboards#index', as: :authenticated_root
     get 'dashboard', to: 'dashboards#index', as: 'dashboard'
     get  'report', to: 'reports#index', as: 'report'
+    get 'lineselect', to: 'dashboards#lineselect', as: 'lineselect'
     post 'search', to: 'dashboards#search', defaults: { format: :js }
     resources :users, only: [:new, :create]
     resources :patients, only: [ :create, :edit, :update ] do

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -29,4 +29,15 @@ class DashboardsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  describe 'lineselect method' do
+    before do
+      get :lineselect
+    end
+
+    it 'should return success' do
+      assert_response :success
+    end
+  end
+
 end


### PR DESCRIPTION
Added a rough line select view, route & associated test as spelled out in issue #683. It probably needs a pass from an actual frontend developer. :smile_cat: 

This pull request makes the following changes:
* adds the line select view & route
* adds a test for that route

![dcaf line select draft](https://cloud.githubusercontent.com/assets/6129479/19582922/94fb33a2-9706-11e6-99e5-8ca043593ba4.png)


It relates to the following issue #s: 
* Bumps #683 
