### PR TITLE
Turn content security policy reporting uri into an env var

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,12 @@ class ApplicationController < ActionController::Base
 
   # Add CSP
   def csp_headers
-    response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline'; object-src; report-uri https://fdb0d6ba398e6ae4b6f8d2f82e773464.report-uri.io/r/default/csp/reportOnly"
+    response.headers['Content-Security-Policy-Report-Only'] =
+      "default-src 'self'; " \
+      "script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; " \
+      "font-src 'self' fonts.gstatic.com; " \
+      "style-src 'self' 'unsafe-inline'; " \
+      "object-src; " \
+      "report-uri https://#{ENV['CSP_VIOLATION_URI']}/csp/reportOnly"
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Piggybacks off @mccabe615 's work in #672 -- pretty much identical except for adding a DCAF-specific reporting URI. 

Env var additions are reflected in heroku. See #672 for a deeper explanation.

No view changes. 