### PR TITLE
Email on user create; no password entry in form

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,8 @@ class UsersController < ApplicationController
   def create
     raise 'Permission Denied' unless current_user.admin?
     @user = User.new(user_params)
+    hex = SecureRandom.urlsafe_base64
+    @user.password, @user.password_confirmation = hex
     if @user.save
       flash[:success] = 'User created!'
       redirect_to session.delete(:return_to)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email)
   end
 
   def retrieve_patients

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,4 +6,9 @@ class UserMailer < Devise::Mailer
     @user = User.find(id)
     mail to: @user.email, subject: 'Your password has changed'
   end
+
+  def account_created(id)
+    @user = User.find(id)
+    mail to: @user.email, subject: 'Your DCAF account has been created'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User
   include Mongoid::Enum
   include Mongoid::Userstamp::User
 
+  after_create :send_account_created_email, if: :persisted?
+
   # Devise modules
   devise  :database_authenticatable,
           :registerable,
@@ -157,5 +159,9 @@ class User
   def send_password_change_email
     # @user = User.find(id)
     UserMailer.password_changed(id).deliver_now
+  end
+
+  def send_account_created_email
+    UserMailer.account_created(id).deliver_now
   end
 end

--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -1,0 +1,6 @@
+<p>Hi <%= @user.name %> --</p>
+<p>A CMAPP account has been created for you!</p>
+<p>Please start by heading to the system and resetting your password.</p>
+<p>Email the CM Directors if you experience any difficulties.</p>
+<p>Thanks for your service!</p>
+<p>- Team DCAF</p>

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -1,0 +1,9 @@
+Hi <%= @user.name %> -- A CMAPP account has been created for you!
+
+Please unlock it by heading to the system and resetting your password.
+
+Email the CM Directors if you experience any difficulties.
+
+Thanks for your service!
+
+- Team DCAF

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,8 +3,6 @@
     <%= bootstrap_form_for @user do |f| %>
         <%= f.email_field :email %>
         <%= f.text_field :name %>
-        <%= f.password_field :password, autocomplete: 'off', label: "Password (#{@minimum_password_length || 8} characters minimum)"%>
-        <%= f.password_field :password_confirmation, autocomplete: 'off'%>
         <%= f.submit "Add", class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -17,22 +17,18 @@ class CreateUserTest < ActionDispatch::IntegrationTest
 
     it 'should be able to create user' do
       assert_difference('User.count', 1) do
-        assert_text 'Create User'
-        click_link 'Create User'
+        assert_difference 'Devise.mailer.deliveries.count', 1 do
+          assert_text 'Create User'
+          click_link 'Create User'
 
-        assert has_field? 'Email'
-        fill_in 'Email', with: 'test@test.com'
+          assert has_field? 'Email'
+          fill_in 'Email', with: 'test@test.com'
 
-        assert has_field? 'Name'
-        fill_in 'Name', with: 'Test User'
+          assert has_field? 'Name'
+          fill_in 'Name', with: 'Test User'
 
-        assert has_field? 'Password'
-        fill_in 'Password', with: 'FCZCidQP4C8GTz', match: :prefer_exact
-
-        assert has_field? 'Password confirmation'
-        fill_in 'Password confirmation', with: 'FCZCidQP4C8GTz'
-
-        click_button 'Add'
+          click_button 'Add'
+        end
       end
 
       user = User.find_by(email: 'test@test.com')
@@ -47,13 +43,12 @@ class CreateUserTest < ActionDispatch::IntegrationTest
       assert_text "can't be blank"
 
       fill_in 'Email', with: 'test@test'
-      fill_in 'Password', with: 'asdfasdf', match: :prefer_exact
-      click_button 'Add'
+
+      assert_no_difference 'Devise.mailer.deliveries.count' do
+        click_button 'Add'
+      end
 
       assert_text 'is invalid'
-      assert_text 'must include at least one lowercase letter, one uppercase '\
-                  'letter, and one digit.'
-      assert_text "doesn't match Password"
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Triggers an email on account create, adds some very dry and very stock templates, and programmatically generates a scrambled password so we aren't emailing around passwords.

No issues or significant view changes.