### PR TITLE
Render new patient partial even if a search does not return results #675

### DIFF
--- a/app/views/dashboards/search.js.erb
+++ b/app/views/dashboards/search.js.erb
@@ -1,6 +1,6 @@
 $('#search_results_shell').empty();
-<% if @results.blank? %>
-  $("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
-<% else %>
+<% if @results.any? %>
   $("#search_results_shell").append("<%= escape_javascript(render partial: 'dashboards/table_content', locals: { title: 'Search results', table_type: 'search_results', patients: @results } ) %>");
 <% end %>
+$("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
+

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -1,4 +1,4 @@
-<h3><small>Your search produced no results, so add a new patient:</small></h3>
+<h3><small>Add a new patient:</small></h3>
 
 <%= bootstrap_form_for patient do |f| %>
   <div class="col-sm-2">

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -1,4 +1,8 @@
-<h3><small>Add a new patient:</small></h3>
+<% if @results.blank? %>
+  <h3><small>Your search produced no results, so add a new patient:</small></h3>
+<% else %>
+  <h3><small>Add a new patient:</small></h3>
+<% end %>
 
 <%= bootstrap_form_for patient do |f| %>
   <div class="col-sm-2">

--- a/test/integration/render_new_patient_partial.rb
+++ b/test/integration/render_new_patient_partial.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class RenderNewPatientPartial < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+    @user = create :user
+    log_in_as @user
+    @patient = create :patient, name: 'Susan Everyteen',
+                                primary_phone: '111-222-3333',
+                                other_contact: 'Yolo Goat',
+                                other_phone: '222-333-4455'
+    @pregnancy = create :pregnancy, patient: @patient
+  end
+
+  after do
+    Capybara.use_default_driver
+  end
+
+  describe 'returning no results from a search', js: true do
+    it 'should display the new patient partial without search results' do
+      fill_in 'search', with: 'Nobody Real Here'
+      click_button 'Search'
+
+      refute has_text? 'Search results'
+      within :css, '#search_results_shell' do
+        assert has_text? 'Add a new patient'
+        assert_equal 'Nobody Real Here', find_field('Name').value, find_field('Name').value
+      end
+    end
+  end
+
+  describe 'returning a partial match in a search', js: true do
+    it 'should display the partial match record and the new patient partial' do
+      fill_in 'search', with: 'susan every'
+      click_button 'Search'
+
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
+      within :css, '#search_results_shell' do
+        assert has_text? 'Add a new patient'
+        assert_equal 'susan every', find_field('Name').value
+      end
+    end
+  end
+  
+  describe 'returning an exact match in a search', js: true do
+    it 'should display the exact match record and the new patient partial' do
+      fill_in 'search', with: 'Susan Everyteen'
+      click_button 'Search'
+
+      assert has_text? 'Search results'
+      assert has_text? 'Susan Everyteen'
+      within :css, '#search_results_shell' do
+        assert has_text? 'Add a new patient'
+        assert_equal 'Susan Everyteen', find_field('Name').value
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes the following changes:
* edits search.js.erb to display new patient partial even if no search results were returned
* edits new patient partial to display different headings based on whether search results were returned
* add integration test

It relates to the following issue #s: 
* New patient partial should display as the result of a search regardless of whether it returns results #675

![no results returned](https://cloud.githubusercontent.com/assets/7366046/19710345/b6fa7c1c-9afb-11e6-9b11-fdd62db4ee8d.png)
![partial_match_search](https://cloud.githubusercontent.com/assets/7366046/19710348/ba777746-9afb-11e6-946b-bc23f95c1753.png)



