### PR TITLE
Improvements to Dockerfile, reducing layers, etc...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,33 @@
 FROM rails:4.2.6
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
+# configure environment variable
+ENV DCAF_DIR=/usr/src/app
+
 # install packages
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev 
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libpq-dev \ 
+    libxml2-dev \
+    libxslt1-dev \
+    nodejs \
+    npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# for nokogiri
-RUN apt-get install -y libxml2-dev libxslt1-dev
+# symlink which nodejs to node
+RUN ln -s `which nodejs` /usr/bin/node
 
-# for a JS runtime
-RUN apt-get install -y nodejs && ln -s `which nodejs` /usr/bin/node
-RUN apt-get install -y npm
-
-# for phantomjs
+# install phantomjs
 RUN npm install -g phantomjs-prebuilt
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-COPY Gemfile /usr/src/app/
-COPY Gemfile.lock /usr/src/app/
+RUN mkdir -p ${DCAF_DIR}
+WORKDIR ${DCAF_DIR}
+COPY Gemfile ${DCAF_DIR}
+COPY Gemfile.lock ${DCAF_DIR}
 RUN bundle install
 
-COPY . /usr/src/app
+COPY . ${DCAF_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -qq && apt-get install -y \
     libxslt1-dev \
     nodejs \
     npm \
-    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # symlink which nodejs to node


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

A quick look at the Dockerfile today, I saw some room for improvement. Reducing the amount of layers created, removing apt-get cache, some DRY stuff. 

This pull request makes the following changes:
* Modify Dockerfile to do apt-get install all in one fell swoop
* Also modify Dockerfile to do apt-get update in same layer as install to prevent caching issues
* ENV variable for DCAF_DIR so it can be changed in one place rather than 4-5 (can't remember)
* Addition of cleaning temp files, apt-get clean to reduce image size

Best practices gleaned from:
* https://intercityup.com/blog/downsizing-docker-containers.html
* https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/