### PR TITLE
Migrate from rails to ruby Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ruby:2.3.1-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
-ENV DCAF_DIR=/usr/src/app
+ENV DCAF_DIR=/usr/src/app \
+    BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" \
+    APP_DEPENDENCIES="nodejs"
 
 # get our gem house in order
 RUN mkdir -p ${DCAF_DIR}
@@ -11,16 +13,12 @@ COPY Gemfile ${DCAF_DIR}
 COPY Gemfile.lock ${DCAF_DIR}
 
 # install packages
-RUN apk add --update \
-    build-base \
-    libxml2-dev \
-    libxslt-dev \
-    linux-headers \
-    nodejs && \
+RUN apk --no-cache add \
+    ${BUILD_DEPENDENCIES} \
+    ${APP_DEPENDENCIES} && \
     gem install bundler --no-ri --no-rdoc && \
     cd ${DCAF_DIR} ; bundle install --without development test && \
-    apk del build-base && \
-    rm -rf /var/cache/apk/*
+    apk del ${BUILD_DEPENDENCIES} 
 
 # symlink which nodejs to node
 RUN ln -s `which nodejs` /usr/bin/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,33 @@
 FROM rails:4.2.6
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
+# configure environment variable
+ENV DCAF_DIR=/usr/src/app
+
 # install packages
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev 
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libpq-dev \ 
+    libxml2-dev \
+    libxslt1-dev \
+    nodejs \
+    npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# for nokogiri
-RUN apt-get install -y libxml2-dev libxslt1-dev
+# symlink which nodejs to node
+RUN ln -s `which nodejs` /usr/bin/node
 
-# for a JS runtime
-RUN apt-get install -y nodejs && ln -s `which nodejs` /usr/bin/node
-RUN apt-get install -y npm
-
-# for phantomjs
+# install phantomjs
 RUN npm install -g phantomjs-prebuilt
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-COPY Gemfile /usr/src/app/
-COPY Gemfile.lock /usr/src/app/
+RUN mkdir -p ${DCAF_DIR}
+WORKDIR ${DCAF_DIR}
+COPY Gemfile ${DCAF_DIR}
+COPY Gemfile.lock ${DCAF_DIR}
 RUN bundle install
 
-COPY . /usr/src/app
+COPY . ${DCAF_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -qq && apt-get install -y \
     libxslt1-dev \
     nodejs \
     npm \
-    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # symlink which nodejs to node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM rails:4.2.6
+FROM ruby:2.3.1-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
 ENV DCAF_DIR=/usr/src/app
 
+# get our gem house in order
+RUN mkdir -p ${DCAF_DIR}
+WORKDIR ${DCAF_DIR}
+COPY Gemfile ${DCAF_DIR}
+COPY Gemfile.lock ${DCAF_DIR}
+
 # install packages
-RUN apt-get update -qq && apt-get install -y \
-    build-essential \
-    libpq-dev \ 
+RUN apk add --update \
+    build-base \
     libxml2-dev \
-    libxslt1-dev \
-    nodejs \
-    npm \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    libxslt-dev \
+    linux-headers \
+    nodejs && \
+    gem install bundler --no-ri --no-rdoc && \
+    cd ${DCAF_DIR} ; bundle install --without development test && \
+    apk del build-base && \
+    rm -rf /var/cache/apk/*
 
 # symlink which nodejs to node
 RUN ln -s `which nodejs` /usr/bin/node
@@ -23,10 +31,11 @@ RUN npm install -g phantomjs-prebuilt
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-RUN mkdir -p ${DCAF_DIR}
+RUN addgroup dcaf && adduser -s /bin/bash -D -G dcaf dcaf
+RUN chown -R dcaf:dcaf ${DCAF_DIR}
+USER dcaf
 WORKDIR ${DCAF_DIR}
-COPY Gemfile ${DCAF_DIR}
-COPY Gemfile.lock ${DCAF_DIR}
-RUN bundle install
 
 COPY . ${DCAF_DIR}
+
+EXPOSE 3000


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Sooooo this switches the Dockerfile from rails (deprecated) to ruby, also switches to using alpine from debian, and trims down ruby quite a bit. End result is the image is half the previous size, should run faster, etc... This PR would supercede #720 #722 and #723  

Testing looked ok to me, someone with much more knowledge of the ecosystem should definitely examine since it's an OS change, etc...

This pull request makes the following changes:
* Switches to ruby:3.2.1-alpine for base image
* Rejumbling of packages installed
* Switches to using a dcaf user ( consistent with #722 )
* Adds an expose for port 3000
* Adds dockerignore file 

It relates to the following issue #s: 
* Fixes #721 