### PR TITLE
Add tzdata-info to run rails server in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ruby:2.3.1-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
-ENV DCAF_DIR=/usr/src/app
+ENV DCAF_DIR=/usr/src/app \
+    BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" \
+    APP_DEPENDENCIES="nodejs"
 
 # get our gem house in order
 RUN mkdir -p ${DCAF_DIR}
@@ -11,16 +13,12 @@ COPY Gemfile ${DCAF_DIR}
 COPY Gemfile.lock ${DCAF_DIR}
 
 # install packages
-RUN apk add --update \
-    build-base \
-    libxml2-dev \
-    libxslt-dev \
-    linux-headers \
-    nodejs && \
+RUN apk --no-cache add \
+    ${BUILD_DEPENDENCIES} \
+    ${APP_DEPENDENCIES} && \
     gem install bundler --no-ri --no-rdoc && \
     cd ${DCAF_DIR} ; bundle install --without development test && \
-    apk del build-base && \
-    rm -rf /var/cache/apk/*
+    apk del ${BUILD_DEPENDENCIES} 
 
 # symlink which nodejs to node
 RUN ln -s `which nodejs` /usr/bin/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM rails:4.2.6
+FROM ruby:2.3.1-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
 ENV DCAF_DIR=/usr/src/app
 
+# get our gem house in order
+RUN mkdir -p ${DCAF_DIR}
+WORKDIR ${DCAF_DIR}
+COPY Gemfile ${DCAF_DIR}
+COPY Gemfile.lock ${DCAF_DIR}
+
 # install packages
-RUN apt-get update -qq && apt-get install -y \
-    build-essential \
-    libpq-dev \ 
+RUN apk add --update \
+    build-base \
     libxml2-dev \
-    libxslt1-dev \
-    nodejs \
-    npm \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    libxslt-dev \
+    linux-headers \
+    nodejs && \
+    gem install bundler --no-ri --no-rdoc && \
+    cd ${DCAF_DIR} ; bundle install --without development test && \
+    apk del build-base && \
+    rm -rf /var/cache/apk/*
 
 # symlink which nodejs to node
 RUN ln -s `which nodejs` /usr/bin/node
@@ -23,10 +31,11 @@ RUN npm install -g phantomjs-prebuilt
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-RUN mkdir -p ${DCAF_DIR}
+RUN addgroup dcaf && adduser -s /bin/bash -D -G dcaf dcaf
+RUN chown -R dcaf:dcaf ${DCAF_DIR}
+USER dcaf
 WORKDIR ${DCAF_DIR}
-COPY Gemfile ${DCAF_DIR}
-COPY Gemfile.lock ${DCAF_DIR}
-RUN bundle install
 
 COPY . ${DCAF_DIR}
+
+EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'nokogiri', '>= 1.6.8'
 gem 'newrelic_rpm'
 gem 'mongo_session_store-rails4'
 gem 'mongoid-enum'
+gem 'tzinfo-data', require: false
 
 group :development do
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,8 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.9)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.0.3)
@@ -395,6 +397,7 @@ DEPENDENCIES
   spring
   timecop
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
@@ -403,4 +406,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds `tzinfo-data` gem to make `docker-compose run web` not choke on a timezone error
* Includes everything in #724 

@DarthHater @mchelen can you all take a look and confirm this is cool? This seemed like the least painful solution to the problem (other stuff involves stackoverflow or docker repo arguments over what wild workaround is the least unobtrusive).