### PR TITLE
ACCOUNTANT: Add Fulfillment section to Patient edit view #731

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -1,5 +1,6 @@
 <section id="fulfillment" class="abortion-info tab-pane active">
   <%= bootstrap_form_for patient, html: { id: 'fulfillment_form' }, remote: true do |f| %>
+  <%# bootstrap_form_for @fulfillment, html: { id: 'fulfillment_form' }, remote: true do |f| %>
     <div class="col-sm-12">
       <div class="row">
         <div class="col-sm-12">

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -1,5 +1,5 @@
-<section id="pledge_fulfillment" class="abortion-info tab-pane active">
-  <%= bootstrap_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
+<section id="fulfillment" class="abortion-info tab-pane active">
+  <%= bootstrap_form_for patient, html: { id: 'fulfillment_form' }, remote: true do |f| %>
     <div class="col-sm-12">
       <div class="row">
         <div class="col-sm-12">

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,6 +7,7 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
+    <li><%= link_to 'Pledge Fulfillment', '#pledge_fulfillment', data: { toggle: 'tab' } %></li>
 
   </ul>
   <div class="row">

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,7 +7,8 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
-    <li><%= link_to 'Pledge Fulfillment', '#pledge_fulfillment', data: { toggle: 'tab' } %></li>
+    <li><%= link_to_if(patient.pregnancy.pledge_sent == true, 'Pledge Fulfillment', '#pledge_fulfillment', 
+            data: { toggle: 'tab' }) %></li>
 
   </ul>
   <div class="row">

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,8 +7,10 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
-    <li><%= link_to_if(patient.pregnancy.pledge_sent == true, 'Pledge Fulfillment', '#pledge_fulfillment', 
-            data: { toggle: 'tab' }) %></li>
+    <% if current_user.admin? %>
+      <li><%= link_to_if(patient.pregnancy.pledge_sent == true, 'Pledge Fulfillment', '#pledge_fulfillment', 
+              data: { toggle: 'tab' }) %></li>
+    <% end %>        
 
   </ul>
   <div class="row">

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,9 +7,8 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
-    <% if current_user.admin? %>
-      <li><%= link_to_if(patient.pregnancy.pledge_sent == true, 'Pledge Fulfillment', '#pledge_fulfillment', 
-              data: { toggle: 'tab' }) %></li>
+    <% if current_user.admin? &&patient.pregnancy.pledge_sent == true%>
+      <li><%= link_to 'Pledge Fulfillment', '#pledge_fulfillment', data: { toggle: 'tab' } %></li>
     <% end %>        
 
   </ul>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,8 +7,8 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
-    <% if current_user.admin? &&patient.pregnancy.pledge_sent == true%>
-      <li><%= link_to 'Pledge Fulfillment', '#pledge_fulfillment', data: { toggle: 'tab' } %></li>
+    <% if current_user.admin? && patient.pregnancy.pledge_sent == true %>
+      <li><%= link_to 'Pledge Fulfillment', '#fulfillment', data: { toggle: 'tab' } %></li>
     <% end %>        
 
   </ul>

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -9,26 +9,26 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <%= f.fields_for patient.pregnancy do |pt| %>
-            <%= pt.form_group :resolved_without_dcaf do %>
-              <%= pt.check_box :resolved_without_dcaf, label: 'Pledge Fulfilled' %>
+          <%= f.fields_for patient.build_fulfillment do |pt| %>
+            <%= pt.form_group :pledge_fulfilled do %>
+              <%= pt.check_box :pledge_fulfilled, label: 'Pledge Fulfilled' %>
             <% end %>
           <% end %>
         </div>  
         <div class="info-form-left col-sm-6">
-          <%= f.fields_for patient.pregnancy do |pt| %>
+          <%= f.fields_for patient.build_fulfillment do |pt| %>
             <%= pt.date_field :procedure_date, label: 'Procedure Date', format: '%Y-%m-%d' %>
-            <%= pt.select :procedure_cost, 
+            <%= pt.select :weeks_along, 
                 options_for_select(weeks_options, patient.pregnancy.last_menstrual_period_weeks ), 
                 label: 'Weeks Along at Procedure', 
                 autocomplete: 'off' %>
-            <%= pt.text_field :procedure_cost, label: 'Abortion Care $', autocomplete: 'off', prepend: '$' %>
+            <%= pt.text_field :abortion_care_cost, label: 'Abortion Care $', autocomplete: 'off'%>
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">
-          <%= f.fields_for patient.pregnancy do |pt| %>
-            <%= pt.text_field :procedure_cost, label: 'Check #', autocomplete: 'off'%>
-            <%= pt.date_field :procedure_date, label: 'Date of Check', format: '%Y-%m-%d' %>
+          <%= f.fields_for patient.build_fulfillment do |pt| %>
+            <%= pt.text_field :check_number, label: 'Check #', autocomplete: 'off'%>
+            <%= pt.date_field :date_of_check, label: 'Date of Check', format: '%Y-%m-%d' %>
           <% end %>
         </div>  
       </div>

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -1,0 +1,22 @@
+<section id="pledge_fulfillment" class="abortion-info tab-pane active">
+  <%= bootstrap_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
+    <div class="col-sm-12">
+      <div class="row">
+        <div class="col-sm-12">
+          <h2>Pledge Fulfillment</h2>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="info-form-left col-sm-6">
+          <%=# f.form_group :pledge_fulfilled do %>
+            <%=# f.check_box :pledge_fulfilled, label: 'Pledge Fulfilled' %>
+          <%# end %>
+        </div>
+        <div class="info-form-right col-sm-6">
+          <%=# f.text_field :check_number, label: 'Check #', autocomplete: 'off' %>
+  
+      </div>
+    </div>
+  <% end %>
+</section>

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -21,7 +21,7 @@
                 options_for_select(weeks_options, patient.pregnancy.last_menstrual_period_weeks ), 
                 label: 'Weeks Along at Procedure', 
                 autocomplete: 'off' %>
-            <%= pt.text_field :abortion_care_cost, label: 'Abortion Care $', autocomplete: 'off'%>
+            <%= pt.text_field :abortion_care_cost, label: 'Abortion Care $', autocomplete: 'off', prepend: '$'%>
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -17,15 +17,18 @@
         </div>  
         <div class="info-form-left col-sm-6">
           <%= f.fields_for patient.pregnancy do |pt| %>
-            <%= pt.date_field :procedure_date, label: 'Procedure Date' %>
-            <%= pt.text_field :procedure_cost, label: 'Weeks Along at Procedure' %>
-            <%= pt.text_field :procedure_cost, label: 'Abortion Care $', autocomplete: 'off' %>
+            <%= pt.date_field :procedure_date, label: 'Procedure Date', format: '%Y-%m-%d' %>
+            <%= pt.select :procedure_cost, 
+                options_for_select(weeks_options, patient.pregnancy.last_menstrual_period_weeks ), 
+                label: 'Weeks Along at Procedure', 
+                autocomplete: 'off' %>
+            <%= pt.text_field :procedure_cost, label: 'Abortion Care $', autocomplete: 'off', prepend: '$' %>
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">
           <%= f.fields_for patient.pregnancy do |pt| %>
             <%= pt.text_field :procedure_cost, label: 'Check #', autocomplete: 'off'%>
-            <%= pt.date_field :procedure_date, label: 'Date of Check' %>
+            <%= pt.date_field :procedure_date, label: 'Date of Check', format: '%Y-%m-%d' %>
           <% end %>
         </div>  
       </div>

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -8,14 +8,26 @@
       </div>
 
       <div class="row">
+        <div class="col-sm-12">
+          <%= f.fields_for patient.pregnancy do |pt| %>
+            <%= pt.form_group :resolved_without_dcaf do %>
+              <%= pt.check_box :resolved_without_dcaf, label: 'Pledge Fulfilled' %>
+            <% end %>
+          <% end %>
+        </div>  
         <div class="info-form-left col-sm-6">
-          <%=# f.form_group :pledge_fulfilled do %>
-            <%=# f.check_box :pledge_fulfilled, label: 'Pledge Fulfilled' %>
-          <%# end %>
+          <%= f.fields_for patient.pregnancy do |pt| %>
+            <%= pt.date_field :procedure_date, label: 'Procedure Date' %>
+            <%= pt.text_field :procedure_cost, label: 'Weeks Along at Procedure' %>
+            <%= pt.text_field :procedure_cost, label: 'Abortion Care $', autocomplete: 'off' %>
+          <% end %>
         </div>
         <div class="info-form-right col-sm-6">
-          <%=# f.text_field :check_number, label: 'Check #', autocomplete: 'off' %>
-  
+          <%= f.fields_for patient.pregnancy do |pt| %>
+            <%= pt.text_field :procedure_cost, label: 'Check #', autocomplete: 'off'%>
+            <%= pt.date_field :procedure_date, label: 'Date of Check' %>
+          <% end %>
+        </div>  
       </div>
     </div>
   <% end %>

--- a/app/views/patients/_pledge_fulfillment.html.erb
+++ b/app/views/patients/_pledge_fulfillment.html.erb
@@ -16,7 +16,7 @@
         </div>  
         <div class="info-form-left col-sm-6">
           <%= f.fields_for patient.build_fulfillment do |pt| %>
-            <%= pt.date_field :procedure_date, label: 'Procedure Date', format: '%Y-%m-%d' %>
+            <%= pt.date_field :procedure_date, label: 'Procedure Date' %>
             <%= pt.select :weeks_along, 
                 options_for_select(weeks_options, patient.pregnancy.last_menstrual_period_weeks ), 
                 label: 'Weeks Along at Procedure', 
@@ -27,7 +27,7 @@
         <div class="info-form-right col-sm-6">
           <%= f.fields_for patient.build_fulfillment do |pt| %>
             <%= pt.text_field :check_number, label: 'Check #', autocomplete: 'off'%>
-            <%= pt.date_field :date_of_check, label: 'Date of Check', format: '%Y-%m-%d' %>
+            <%= pt.date_field :date_of_check, label: 'Date of Check' %>
           <% end %>
         </div>  
       </div>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -20,7 +20,7 @@
     <%= render 'patients/call_log', patient: @patient %>
     <%= render 'patients/notes', patient: @patient, note: @note %>
     <% if current_user.admin? && @patient.pregnancy.pledge_sent == true %>
-      <%= render 'patients/pledge_fulfillment', patient: @patient %>
+      <%= render 'patients/fulfillment', patient: @patient %>
     <% end %>  
   </div>
 </div>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -19,5 +19,6 @@
     <%= render 'patients/change_log', patient: @patient %>
     <%= render 'patients/call_log', patient: @patient %>
     <%= render 'patients/notes', patient: @patient, note: @note %>
+    <%= render 'patients/pledge_fulfillment', patient: @patient%>
   </div>
 </div>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -19,6 +19,8 @@
     <%= render 'patients/change_log', patient: @patient %>
     <%= render 'patients/call_log', patient: @patient %>
     <%= render 'patients/notes', patient: @patient, note: @note %>
-    <%= render 'patients/pledge_fulfillment', patient: @patient%>
+    <% if current_user.admin? && @patient.pregnancy.pledge_sent == true %>
+      <%= render 'patients/pledge_fulfillment', patient: @patient %>
+    <% end %>  
   </div>
 </div>

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -36,8 +36,8 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
       visit edit_patient_path @patient
     end
     
-    it 'should show text with no link when the pledge has not been sent' do
-      assert has_text? 'Pledge Fulfillment'
+    it 'should not show the pledge fulfillment link to an admin unless the pledge has been sent' do
+      refute has_text? 'Pledge Fulfillment'
       refute has_link? 'Pledge Fulfillment'
     end
   

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+    @user = create :user, role: 'cm'
+    @admin = create :user, role: 'admin'
+    @patient = create :patient
+    @pregnancy = create :pregnancy, pledge_sent: false
+    log_in_as @user
+    visit edit_patient_path @patient
+  end
+
+  after do
+    Capybara.use_default_driver
+  end
+  
+  log_in_as @user
+  
+  describe 'visiting the edit patient view as a CM' do
+    it 'should not show the pledge fulfillment link to a CM' do
+      refute has_link? 'Pledge Fulfillment'
+    end
+  end
+  
+  sign_out
+  log_in_as @admin
+  
+  describe 'visiting the edit patient view as an admin' do
+    it 'should show text with no link' do
+      assert has_text? 'Pledge Fulfillment'
+      refute has_link? 'Pledge Fulfillment'
+    end
+  end
+  
+  before do
+    @pregnancy.pledge_sent = true 
+  end
+  
+  describe 'visiting the edit patient view as an admin after the pledge is sent' do
+    it 'should show text with no link' do
+      assert has_link? 'Pledge Fulfillment'
+      click_link 'Pledge Fulfillment'
+      assert has_text? 'Procedure Date'
+      assert has_text? 'Check #'
+    end
+  end
+end

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -1,44 +1,55 @@
 require 'test_helper'
 
 class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
+  
   before do
     Capybara.current_driver = :poltergeist
-    @user = create :user, role: 'cm'
-    @admin = create :user, role: 'admin'
-    @patient = create :patient
-    @pregnancy = create :pregnancy, pledge_sent: false
-    log_in_as @user
-    visit edit_patient_path @patient
+    @user = create :user, role: :cm
+    @admin = create :user, role: :admin
+    @patient = create :patient, clinic_name: 'Nice Clinic', appointment_date: DateTime.now + 14
+    @pregnancy = create :pregnancy, patient: @patient, pledge_sent: false, dcaf_soft_pledge: 500
   end
 
   after do
     Capybara.use_default_driver
   end
   
-  log_in_as @user
-  
   describe 'visiting the edit patient view as a CM' do
+    before do
+      log_in_as @user
+      visit edit_patient_path @patient
+    end
+    
+    after do
+      sign_out
+    end
+    
     it 'should not show the pledge fulfillment link to a CM' do
+      refute has_text? 'Pledge Fulfillment'
       refute has_link? 'Pledge Fulfillment'
     end
   end
   
-  sign_out
-  log_in_as @admin
-  
   describe 'visiting the edit patient view as an admin' do
-    it 'should show text with no link' do
+    before do
+      log_in_as @admin
+      visit edit_patient_path @patient
+    end
+    
+    it 'should show text with no link when the pledge has not been sent' do
       assert has_text? 'Pledge Fulfillment'
       refute has_link? 'Pledge Fulfillment'
     end
-  end
   
-  before do
-    @pregnancy.pledge_sent = true 
-  end
-  
-  describe 'visiting the edit patient view as an admin after the pledge is sent' do
-    it 'should show text with no link' do
+    it 'should show a link to the pledge fulfillment tab after the pledge has been sent' do
+      find('#submit-pledge-button').click
+      find('#submit-pledge-to-p2').click
+      find('#submit-pledge-to-p3').click
+      check 'I sent the pledge'
+      find('#submit-pledge-finish').click
+      click_link 'Dashboard'
+      visit edit_patient_path @patient
+      
       assert has_link? 'Pledge Fulfillment'
       click_link 'Pledge Fulfillment'
       assert has_text? 'Procedure Date'


### PR DESCRIPTION
This pull request makes the following changes:
* render fulfillment partial if admin and pledge has been sent
* show link if admin and make link clickable after pledge has been sent
* create fulfillment form hooked up to model
* create integration test to verify when link shows and when it becomes clickable

![pledge_sent_true](https://cloud.githubusercontent.com/assets/7366046/20465268/582df78c-af27-11e6-9e9d-de969681fee9.png)

Issues
* check weeks along field: is it showing the correct data?
* abortion care $ field: they need to enter an integer, not a string with "$", is this clear?
* boolean checkbox label: this is supposed to be bold by default 
* the disabled link is not lining up with the other links

![pledge_sent_false](https://cloud.githubusercontent.com/assets/7366046/20465321/22af776a-af28-11e6-9ef6-43617bdf4954.png)

* currently using date_field because datepicker wasn't working. I'm not sure how to override the defaults and it might be easier to get datepicker working, if you want it exactly like in the mockup. Currently if you click or hover anywhere in the field a black arrow appears, if you click on that the calendar pops up, or you can click on the placeholder and the M/D/Y fields become active, then you can enter the date in directly.

![date_field default](https://cloud.githubusercontent.com/assets/7366046/20465340/a0873704-af28-11e6-99d3-ac45601e2f7b.png)




