### PR TITLE
[WIP] change the view to accept multiple pledges #747

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -9,3 +9,20 @@ $(document).on "click", "#toggle-call-log", ->
 
 $(document).on "change", ".edit_patient", ->
   $(this).submit()
+
+$(document).on "click", ".add-button", ->
+  value = $(".pledges-select").val()
+  if value == ""
+    alert("You have to select a value from the dropdown menu!")
+  else
+    html = """
+          <div class="form-group">
+            <label class="control-label"> #{value} </label>
+            <div class="input-group">
+              <span class="input-group-addon">$</span>
+              <input type="text" autocomplete="off" class="form-control">
+            </div>
+          </div>
+          """
+    $("#pledge-contributions").append(html)
+

--- a/app/assets/stylesheets/patients.scss
+++ b/app/assets/stylesheets/patients.scss
@@ -1,3 +1,9 @@
 // Place all the styles related to the Patients controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.add-button {
+  border: 0px;
+  span {
+    padding-right: 10px;
+  }
+}

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -56,4 +56,11 @@ module PatientsHelper
   def disable_continue?(patient)
     patient.pregnancy.pledge_info_present? ? 'disabled' : ''
   end
+
+  def pledges_options
+    [nil,"Baltimore Abortion Fund", "Richmond Reproductive Freedom Project",
+      "Blue Ridge Abortion Assistance Fund", "Tiller Fund (NNAF)",
+      "Carolina Abortion Fund", "Women's Medical Fund (Philadelphia)",
+      "NYAAF (New York)", "Other"]
+  end
 end

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -6,13 +6,19 @@
           <h2>Abortion information</h2>
         </div>
       </div>
+
+      <div class="row">
+        <div class="col-sm-12">
+          <h3> Clinic Details </h3>
+        </div>
+      </div>
+
       <div class="row">
         <div class="col-sm-6">
           <div class="info-form-left">
             <%#= f.fields_for (patient.clinic || patient.build_clinic) do |cl| %>
-              <h3>Clinic details</h3>
                 <%= f.select :clinic_name, options_for_select(clinic_options, patient.clinic_name) %>
-                <%#= cl.select :name, options_for_select(clinic_options, patient.clinic.name), label: 'Clinic name', autocmomplete: 'off' %>
+                <%#= cl.select :name, options_for_select(clinic_options, patient.clinic.name), label: 'Clinic name', autocomplete: 'off' %>
                 <%#= cl.text_field :name, label: 'Clinic name:', autocomplete: 'off' %>
                 <%#= cl.text_field :street_address_1, label: 'Street address 1:', autocomplete: 'off' %>
                 <%#= cl.text_field :street_address_2, label: 'Street address 2:', autocomplete: 'off' %>
@@ -26,7 +32,11 @@
               </div>
               <%#= cl.text_field :zip, label: 'ZIP:', autocomplete: 'off' %>
             <%# end %>
+          </div>
+        </div>
 
+        <div class="col-sm-6">
+          <div class="info-form-right">
             <%= f.fields_for patient.pregnancy do |pt| %>
               <%= pt.form_group :resolved_without_dcaf, label: { text: 'Resolved without assistance from DCAF' } do %>
                 <%= pt.check_box :resolved_without_dcaf, label: '' %>
@@ -34,17 +44,36 @@
             <% end %>
           </div>
         </div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-12">
+          <h3>Cost details</h3>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-6">
+          <%= f.fields_for patient.pregnancy do |pt| %>
+            <%= pt.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
+          <% end %>
+        </div>
 
         <div class="col-sm-6">
-          <div class="info-form-right">
-            <h3>Cost details</h3>
+          <div id="pledge-contributions">
             <%= f.fields_for patient.pregnancy do |pt| %>
-              <%= pt.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
               <%= pt.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
-               <%= pt.text_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
-                 <%= pt.text_field :dcaf_soft_pledge, label: 'DCAF soft pledge', autocomplete: 'off', prepend: '$' %>
+              <%= pt.text_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
+              <%= pt.text_field :dcaf_soft_pledge, label: 'DCAF soft pledge', autocomplete: 'off', prepend: '$' %>
             <% end %>
           </div>
+          <div class="form-group">
+            <label>Select Other</label>
+            <%= select_tag :pledges, options_for_select(pledges_options), class: "pledges-select form-control"  %>
+          </div>
+          <button class="button btn-success add-button">
+            <span class="glyphicon glyphicon-plus-sign"></span>Add Other
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This changes the `_abortion_info.html.erb` partial to look like the changes recommended in #747

This pull request makes the following changes:
changes the view to look like the one #747 by reposissioning the input fields and adding a button to add other pledge sources

![screen shot 2016-11-27 at 2 09 02 am](https://cloud.githubusercontent.com/assets/6386302/20646473/1e464946-b447-11e6-8b39-e3272e9833a6.png)
 
![screen shot 2016-11-27 at 2 09 23 am](https://cloud.githubusercontent.com/assets/6386302/20646476/311e19c2-b447-11e6-8fa3-4d41e0c27f3e.png)

clicking on the add other button after selecting a field will add another input field with the name corresponding to the selection 

![screen shot 2016-11-27 at 2 09 54 am](https://cloud.githubusercontent.com/assets/6386302/20646485/665ee85a-b447-11e6-8cc4-2f01e63dab66.png)

Issues:
 * The user can continuously add input fields even the same ones over and over. There are no checks to see which input fields have been generated thus far
*  The html looks correct but it needs to be properly wired to the back end so that the values are being routed to the correct controllers, methods, params etc..
* Need some tests
* Not entirely sure what the best practices for client side scripting are a good code review is needed here

I'm not sure this is the exact behaviour requested but I think it be useful to be able to clarify on slack.  So I kindly request an invite to join the slack channel my email is guilhermerpmansur@gmail.com 🙃 

It relates to the following issue #s: 
#747 

