### PR TITLE
Retitle to DARIA; cleaner line display, note about unimplemented clinic model

### DIFF
--- a/app/helpers/lines_helper.rb
+++ b/app/helpers/lines_helper.rb
@@ -4,7 +4,7 @@ module LinesHelper
   end
 
   def current_line_display
-    "Line: #{session[:line]}" if session[:line]
+    "Your current line: #{session[:line]}" if session[:line]
   end
 
   def current_line

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -1,4 +1,5 @@
 # Object representing a clinic that a fund works with.
+# NOTE: NOT CURRENTLY IMPLEMENTED. DO NOT USE. USE Patient#clinic_name instead.
 class Clinic
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -27,5 +28,4 @@ class Clinic
                 track_update: true,
                 track_destroy: true
   mongoid_userstamp user_model: 'User'
-
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -63,6 +63,7 @@ class Patient
   index(name: 1)
   index(other_contact: 1)
   index(urgent_flag: 1)
+  index(_line: 1)
 
   # Validations
   validates :name,

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to 'DCAF Case Manager', root_path, class: 'navbar-brand' %>
+      <%= link_to "DARIA - DC Abortion Fund", root_path, class: 'navbar-brand' %>
     </div>
     <div class="collapse navbar-collapse">
       <%= render 'layouts/navigation_links' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= content_for?(:title) ? yield(:title) : "DCAF Case Management System" %></title>
+    <title><%= content_for?(:title) ? yield(:title) : "DARIA" %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "DCAF" %>">
     <meta name='ROBOTS' content='NOINDEX, NOFOLLOW'>
     <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/test/helpers/lines_helper_test.rb
+++ b/test/helpers/lines_helper_test.rb
@@ -14,7 +14,7 @@ class LinesHelperTest < ActionView::TestCase
 
       %w(DC MD VA).each do |state|
         session[:line] = state
-        assert_equal current_line_display, "Line: #{state}"
+        assert_equal current_line_display, "Your current line: #{state}"
         assert_equal current_line, state.to_s
       end
     end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -14,11 +14,11 @@ class RoutingTest < ActionDispatch::IntegrationTest
   end
 
   it 'should not display navigation partial on sign in' do
-    refute has_text? 'DCAF Case Manager'
+    refute has_text? 'DARIA - DC Abortion Fund'
     visit root_path
     @user = create :user
     log_in_as @user
     visit authenticated_root_path
-    assert has_text? 'DCAF Case Manager'
+    assert has_text? 'DARIA - DC Abortion Fund'
   end
 end

--- a/test/integration/select_line_test.rb
+++ b/test/integration/select_line_test.rb
@@ -20,7 +20,7 @@ class SelectLineTest < ActionDispatch::IntegrationTest
       choose 'DC'
       click_button 'Select your line for this session'
       assert_equal current_path, authenticated_root_path
-      assert has_content? 'Line: DC'
+      assert has_content? 'Your current line: DC'
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Changes the app name and title to DARIA, per CM corps consensus
* Makes a note that we haven't implemented the clinic model
* Edits the call line display to clarify 'your current call line' rather than just 'line', which didn't specify a user's session or the patient they were looking at
* Indexes Patient on line

It relates to the following issue #s: 
* Fixes #719 
* Fixes #2 
* nudges #766 
