### PR TITLE
link directly to the /joinslack page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Next major project milestone: December 5: Launch to full organization!
 
 ## [Come hang out with us on slack!](https://codefordc.slack.com/messages/dcaf_case_management)
-Join via the [Code for DC website](http://codefordc.org/).
+Join via the [Code for DC website](http://codefordc.org/joinslack).
 
 ## Project description
 This project is a case management system for the [DC Abortion Fund](http://dcabortionfund.org/), an all-volunteer, 501(c)(3) non-profit organization that gives grants to people in DC, Maryland, and Virginia who cannot afford the full cost of abortion care. Currently, a team of around 75 case managers are taking about 3,500 calls a year and entering them all into shared Excel sheets. We're replacing that with a nice, clean, usable and scalable rails application! This will let DCAF continue to operate at a fast pace, and prevent volunteers from getting frustrated with shared Excel sheets.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review! Now the readme will take people interested in joining Slack directly to the page where they can do that.

This pull request makes the following changes:
* `README.md` links directly to the the page on codefordc.org where people can join Slack.
