### PR TITLE
Quick tweaks to namespace the ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Use 'Control + C' for both MongoDB and Rails to stop their servers from running.
 We can use Google SSO for login, but setting it up requires a few more hoops to jump through. You'll need to:
 
 * Obtain values for the following from @colinxfleming or @DarthHater
-* Define the environment variables `GOOGLE_KEY` and `GOOGLE_SECRET`. On OSX or linux, you can do this by two lines variables to your `.bash_profile` (or whatever you use):
-    - `export GOOGLE_KEY='(public key for Google SSO API)'`
-    - `export GOOGLE_SECRET='(secret key for Google SSO API)'`
+* Define the environment variables `DCAF_GOOGLE_KEY` and `DCAF_GOOGLE_SECRET`. On OSX or linux, you can do this by two lines variables to your `.bash_profile` (or whatever you use):
+    - `export DCAF_GOOGLE_KEY='public key for Google SSO API'`
+    - `export DCAF_GOOGLE_SECRET='secret key for Google SSO API'`
 
 Once you've done this, Sign In with Google functionality should start working for you. (We mock this in test environments, so you don't have to worry about that.)
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -235,7 +235,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :google_oauth2, ENV['GOOGLE_KEY'], ENV['GOOGLE_SECRET']
+  config.omniauth :google_oauth2, ENV['DCAF_GOOGLE_KEY'], ENV['DCAF_GOOGLE_SECRET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Small tweaks to change the ENV variables from #796 and #802 to be namespaced

This pull request makes the following changes:
* Updates env variables in devise.rb
* Updates README.md to new variable names