### PR TITLE
Small change from ENV to ARG since these values are all build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ruby:2.3.1-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
-ENV DCAF_DIR=/usr/src/app \
-    BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" \
-    APP_DEPENDENCIES="nodejs"
+ARG DCAF_DIR=/usr/src/app 
+ARG BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" 
+ARG APP_DEPENDENCIES="nodejs"
 
 # get our gem house in order
 RUN mkdir -p ${DCAF_DIR} && cd ${DCAF_DIR}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Simply stated, the ENV variables in the Dockerfile can benefit from being build time ARG instead. No reason to persist them as the application does not need them post build. Also allows someone to override them (if need be) via the docker build command. 

This pull request makes the following changes:
* Switches ENV to ARG in Dockerfile, single lines them (no multiline for ARG it appears)
