### PR TITLE
Issue 667-Pulling Record New Call link right

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -143,8 +143,6 @@ h1.title {
 }
 h2 {
   font-size: 2.215rem;
-  padding-top: 15px;
-  padding-bottom: 15px;
 }
 h3 {
   font-size: 1.625rem;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -143,6 +143,8 @@ h1.title {
 }
 h2 {
   font-size: 2.215rem;
+  padding-top: 15px;
+  padding-bottom: 15px;
 }
 h3 {
   font-size: 1.625rem;

--- a/app/assets/stylesheets/calls.scss
+++ b/app/assets/stylesheets/calls.scss
@@ -20,6 +20,11 @@ h4.calls-phone {
   text-decoration: underline;
 }
 
+.new-call-entry {
+  font-size: 17px;
+  font-size: 100%;
+}
+
 #calls-btn {
   font-size: 17px;
   padding: 10px 40px;

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -2,7 +2,7 @@
   <div class="margin-bottom col-sm-12">
     <h2>
       Call Log
-      <small><%= link_to "Record new call <span class='glyphicon glyphicon-earphone' aria-hidden='true'></span><span class='sr-only'>Call</span>".html_safe, "#call-#{@patient.primary_phone_display}", data: {toggle: "modal"} %></small>
+      <span class="pull-right new-call-entry"><small><%= link_to "Record new call".html_safe, "#call-#{@patient.primary_phone_display}", data: {toggle: "modal"} %></small></span>
     </h2>
 
     <%= render partial: 'calls/new_call', locals: {patient: @patient} %>

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -2,7 +2,7 @@
   <div class="margin-bottom col-sm-12">
     <h2>
       Call Log
-      <span class="pull-right new-call-entry"><small><%= link_to "Record new call".html_safe, "#call-#{@patient.primary_phone_display}", data: {toggle: "modal"} %></small></span>
+      <span class="pull-right new-call-entry"><small><%= link_to "Record new call", "#call-#{@patient.primary_phone_display}", data: {toggle: "modal"} %></small></span>
     </h2>
 
     <%= render partial: 'calls/new_call', locals: {patient: @patient} %>


### PR DESCRIPTION
Three simple fixes:
1. Additional padding on section header.
2. Adding classes to "Record new call" link to pull it right, ensure font height.
3. Removing call glyphicon.  

The view should now look like this:
![screen shot 2017-01-13 at 1 42 25 pm](https://cloud.githubusercontent.com/assets/12383179/21941314/2fb3f952-d996-11e6-8325-fb0e56053640.png)

fixes #667 

