### PR TITLE
Tell quality gem to chill out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,14 +19,13 @@ gem 'bson_ext'
 gem 'figaro'
 gem 'bootstrap_form'
 gem 'bootstrap_form-datetimepicker'
-gem 'quality', require: false
 gem 'nokogiri', '>= 1.6.8'
 gem 'newrelic_rpm'
 gem 'mongo_session_store-rails4'
 gem 'mongoid-enum'
 gem 'tzinfo-data', require: false
 gem 'js-routes'
-gem "omniauth-google-oauth2", "~> 0.2.1"
+gem 'omniauth-google-oauth2', '~> 0.2.1'
 
 group :development do
   gem 'web-console', '~> 2.0'
@@ -34,6 +33,7 @@ group :development do
   gem 'brakeman', require: false
   gem 'ruby_audit', require: false
   gem 'bundler-audit', require: false
+  gem 'quality', '20.1.0', require: false
   # gem 'dawnscanner', require: false # disable until dawnscanner fixes CD prob
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.3.0)
+    rake (12.0.0)
     rdoc (4.2.2)
       json (~> 1.4)
     reek (4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,7 +419,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 0.2.1)
   poltergeist
   puma
-  quality
+  quality (= 20.1.0)
   rails (~> 4.2.7)
   rails_12factor
   rubocop
@@ -438,4 +438,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.2


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

A gem we have, `quality`, is making setup of everything a royal pain in the behind because of a bunch of extra style things it has built into it (for stuff like scala, markdown, python, etc.) This PR gets it to chill out so that people installing from scratch don't have to go on a goose chase.

Also bumps the rake version in the gemfile since THAT is being rude too.

This pull request makes the following changes:
* Hardsets quality to version 20.1.0
* Bumps the rake version since that's crying when you try to run `rake` anything

Note to self not to merge until after the current outstanding set of PRs gets all resolved.