### PR TITLE
Removing table stylings from patient notes headers; implementing MM/D…

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -24,3 +24,28 @@
 .bootstrap_toggle_spacing .checkbox {
   margin-top: 0px;
 }
+
+.pt-phone,.pt-LMP {
+  width: 100px;
+  white-space: nowrap;
+  padding-right: 5px;
+}
+
+.pt-recent-notes {
+  width: 150px;
+}
+
+.glyphicon-remove {
+  color: red;
+  padding: 0px 10px 0px 10px;
+}
+
+.glyphicon-plus-sign {
+  float: right;
+}
+
+.pt-name {
+  a {
+    padding-left: 10px;
+  }
+}

--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -1,0 +1,19 @@
+.name-date-time {
+	padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+  border-top: 1px solid #ddd;
+  font-size: 14px;
+  color: #323a45;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  background: #f1f1f1;
+  display: inline-block;
+  float: left;
+  width: 100%;
+  font-weight: bold;
+}
+
+.notes-body {
+	display: -webkit-inline-box;
+}

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -12,7 +12,7 @@
         <th>Name</th>
         <th>LMP</th>
         <th>Status</th>
-        <th>Appointment date</th>
+        <th>Appt date</th>
         <th>Notes</th>
         <th></th>
         <th></th>
@@ -24,18 +24,18 @@
           <% if local_assigns[:sortable] %>
             <td class="handle"><span class="glyphicon glyphicon-move"></span></td>
           <% end %>
-          <td><%= patient.primary_phone_display %></td>
-          <td><%= link_to patient.name, edit_patient_path(patient) %></td>
-          <td><%= patient.pregnancy.last_menstrual_period_display_short %></td>
+          <td class="pt-phone"><%= patient.primary_phone_display %></td>
+          <td class="pt-name"><%= link_to patient.name, edit_patient_path(patient) %></td>
+          <td class="pt-LMP"><%= patient.pregnancy.last_menstrual_period_display_short %></td>
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date %></td>
-          <td><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
+          <td class="pt-recent-notes"><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
 
           <% if table_type == 'completed_calls' || table_type == 'urgent_patients' %>
             <td class="blank-td"></td>
           <% else %>
             <% if current_user.patients.include?(patient) %>
-              <td><%= link_to "Remove", remove_patient_path(current_user, patient), method: :patch, data: { confirm: "Are you sure you want to remove #{patient.name} from your call list?" },  remote: true %></td>
+              <td><%= link_to "<span class='glyphicon glyphicon-remove' aria-hidden='true'></span><span class='sr-only'>Remove call</span>".html_safe, remove_patient_path(current_user, patient), method: :patch, data: { confirm: "Are you sure you want to remove #{patient.name} from your call list?" },  remote: true %></td>  
             <% else %>
               <td><%= link_to "Add", add_patient_path(current_user, patient), method: :patch, remote: true %></td>
             <% end %>

--- a/app/views/notes/_notes_table.html.erb
+++ b/app/views/notes/_notes_table.html.erb
@@ -2,13 +2,11 @@
   <tbody>
     <% notes.each do |note| %>
       <% unless note.new_record? %>
+        <div class="notes-wrapper">
+          <p class="name-date-time"><%= note.created_by.name %> <%= note.created_at.display_date %> <%= note.created_at.display_time %></p>
+        </div>
         <tr>
-          <th><%= note.created_at.display_date %></th>
-          <th><%= note.created_at.display_time %></th>
-          <th><%= note.created_by.name %></td>
-        </tr>
-        <tr>
-          <td><%= note.full_text %></td>
+          <p class="notes-body"><%= note.full_text %></p>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/notes/_notes_table.html.erb
+++ b/app/views/notes/_notes_table.html.erb
@@ -2,11 +2,11 @@
   <tbody>
     <% notes.each do |note| %>
       <% unless note.new_record? %>
-        <div class="notes-wrapper">
-          <p class="name-date-time"><%= note.created_by.name %> <%= note.created_at.display_date %> <%= note.created_at.display_time %></p>
-        </div>
         <tr>
-          <p class="notes-body"><%= note.full_text %></p>
+          <th><%= note.created_by.name %> <%= note.created_at.display_date %> <%= note.created_at.display_time %></th>
+        </tr>
+        <tr>
+          <td><%= note.full_text %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -95,8 +95,6 @@
                               checked: patient.special_circumstances.include?('Incest'), namespace: 'Incest' }, 'Incest', '' %>
             <%= f.check_box :special_circumstances, { label: 'Prison', name: 'patient[special_circumstances][]',
                               checked: patient.special_circumstances.include?('Prison'), namespace: 'Prison' }, 'Prison', '' %>
-            <%= f.check_box :special_circumstances, { label: 'Undocumented', name: 'patient[special_circumstances][]',
-                              checked: patient.special_circumstances.include?('Undocumented'), namespace: 'Undocumented' }, 'Undocumented', '' %>
             </div>
           <% end %>
         </div>

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,7 +1,7 @@
 # Extends time class with convenience methods
 class Time
   def display_date
-    getlocal.strftime("%Y-%m-%d")
+    getlocal.strftime("%m-%d-%Y")
   end
 
   def display_time

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,7 +1,7 @@
 # Extends time class with convenience methods
 class Time
   def display_date
-    getlocal.strftime("%m-%d-%Y")
+    getlocal.strftime("%Y-%m-%d")
   end
 
   def display_time


### PR DESCRIPTION
This pull request makes the following changes:
-Removed table styling from patient notes headers
-Added MM/DD/YYYY format for date

-Added padding to call list area
-Replaced "Remove" with glyph icon
-Improved widths

The notes page should look like this:
![localhost-3000-patients-589095435e0dd1cbbbdd33a3-edit](https://cloud.githubusercontent.com/assets/12383179/22469532/53ecee7a-e79a-11e6-8c1a-fe3317570ba5.png)

And the call list area should look like this:
![screen shot 2017-01-31 at 3 18 09 pm](https://cloud.githubusercontent.com/assets/12383179/22483077/b66b9216-e7c9-11e6-9940-25ff444c094b.png)


Thanks @colinxfleming and let me know if anything needs a touch up!

Closes #795 