### PR TITLE
Initial prop up of lets-encrypt changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'mongo_session_store-rails4'
 gem 'mongoid-enum'
 gem 'tzinfo-data', require: false
 gem 'js-routes'
-gem "omniauth-google-oauth2", "~> 0.2.1"
+gem 'omniauth-google-oauth2', '~> 0.2.1'
 gem 'platform-api', git: 'https://github.com/jalada/platform-api', branch: 'master'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'mongoid-enum'
 gem 'tzinfo-data', require: false
 gem 'js-routes'
 gem "omniauth-google-oauth2", "~> 0.2.1"
-gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+gem 'platform-api', git: 'https://github.com/jalada/platform-api', branch: 'master'
 
 group :development do
   gem 'web-console', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'mongoid-enum'
 gem 'tzinfo-data', require: false
 gem 'js-routes'
 gem "omniauth-google-oauth2", "~> 0.2.1"
+gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+
 
 group :development do
   gem 'web-console', '~> 2.0'
@@ -66,4 +68,5 @@ end
 group :production do
   gem 'puma'
   gem 'rails_12factor'
+  gem 'letsencrypt-rails-heroku'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/jalada/platform-api.git
+  remote: https://github.com/jalada/platform-api
   revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
   branch: master
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,16 @@
+GIT
+  remote: git://github.com/jalada/platform-api.git
+  revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
+  branch: master
+  specs:
+    platform-api (0.8.0)
+      heroics (~> 0.0.17)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    acme-client (0.4.1)
+      faraday (~> 0.9, >= 0.9.1)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
       actionview (= 4.2.7.1)
@@ -116,6 +126,7 @@ GEM
     easy_diff (1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
+    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -140,6 +151,12 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
+    heroics (0.0.17)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
+      netrc
     i18n (0.7.0)
     ice_nine (0.11.2)
     jbuilder (2.5.0)
@@ -158,6 +175,9 @@ GEM
     jwt (1.5.6)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letsencrypt-rails-heroku (0.3.0)
+      acme-client (~> 0.4.0)
+      platform-api
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -180,6 +200,7 @@ GEM
     minitest-spec-rails (5.4.0)
       minitest (~> 5.0)
       rails (>= 4.1)
+    moneta (0.8.1)
     mongo (2.2.5)
       bson (~> 4.0)
     mongo_session_store-rails4 (6.0.0)
@@ -204,6 +225,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     newrelic_rpm (3.15.2.317)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -405,6 +427,7 @@ DEPENDENCIES
   jquery-ui-rails
   js-routes
   launchy
+  letsencrypt-rails-heroku
   mini_backtrace
   minitest-ci
   minitest-reporters
@@ -417,6 +440,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.6.8)
   omniauth-google-oauth2 (~> 0.2.1)
+  platform-api!
   poltergeist
   puma
   quality
@@ -438,4 +462,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,11 +41,11 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Do this before forcing SSL
+  # Do this before forcing SSL, see https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#installation for more info
   config.middleware.insert_before ActionDispatch::SSL, Letsencrypt::Middleware
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # Do this AFTER the world hasn't imploded (see previous line)
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,11 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
+  # Do this before forcing SSL
+  config.middleware.insert_before ActionDispatch::SSL, Letsencrypt::Middleware
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Do this AFTER the world hasn't imploded (see previous line)
   config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
+
+  # Use Let's Encrypt for SSL
+  config.middleware.use Letsencrypt::Middleware
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This is the start of changes to hopefully use lets-encrypt for FrEe SsL!!111!

This pull request makes the following changes:
* Adds gem (github reference, YIKES) for heroku API
* Adds lets-encrypt heroku gem
* Middleware mods for production

What's left to be done?
* Lots of environment variables, I think based on the documentation. Best to try this all out on staging with a dry run of the code. https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#configuring
* Heroku configuration: https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#creating-a-heroku-token
* First time use: https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#using-for-the-first-time
* Add scheduled task cron whatever to update cert: https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#adding-a-scheduled-task
* ???
* PROFIT!!!! (in small amounts, actually)

Prod steps based on Staging Dry Run:
- Tried to run heroku plugins:install heroku-cli-oauth
    - Didn’t run because already installed on staging
- Setup ENV variables
- Change ACME_EMAIL to DCAF email (currently using @colinxfleming )
- Deploy branch
- Won’t work on herokuapp url’s since these are SSL enabled by default
    - Need to setup REAL url’s to make sure it works (not an issue in Prod)
- Need to setup cron job (use Heroku scheduler, copy pasta) 

Production
* May need to do some DNS crap: https://devcenter.heroku.com/articles/ssl#change-your-dns-for-all-domains-on-your-app
* Make sure to shut off current SSL endpoint and Expedited SSL

PROFIT!!!!

It relates to the following issue #s: 
* Does code related setup of #748 