### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ruby:2.3.3-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
-ARG DCAF_DIR=/usr/src/app 
-ARG BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" 
-ARG APP_DEPENDENCIES="nodejs"
+ENV DCAF_DIR=/usr/src/app \
+    BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" \
+    APP_DEPENDENCIES="nodejs"
 
 # get our gem house in order
 RUN mkdir -p ${DCAF_DIR} && cd ${DCAF_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.3.3-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable
+# note: move this to three ARG commands when CircleCI updates their docker
 ENV DCAF_DIR=/usr/src/app \
     BUILD_DEPENDENCIES="build-base libxml2-dev libxslt-dev linux-headers" \
     APP_DEPENDENCIES="nodejs"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

@DarthHater It is with a heavy heart that I must announce that CircleCI's docker version is too old to support `ARG`, and it's been busting our builds. There's a long backlog of people on the support forums chirping at them, and they're currently in a closed beta that includes better docker support, so I don't think we'll have to wait long before we start doing this ~ the right way ~. 

This pull request makes the following changes:
* reverts ARG changes in dockerfile in favor of env

It relates to the following issue #s: 
* Fixes #831 
* Bumps #Y
