### PR TITLE
Added helper text to income field on patient edit form

### DIFF
--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -49,6 +49,7 @@
           <%= f.select :income,
                        options_for_select(income_options,
                                           patient.income),
+                                          help: 'Employment, Food Stamps, SS, TANF, etc.',
                                           autocomplete: 'off' %>
           <div class="row">
             <div class="col-sm-6">


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Adds helper text underneath income field on patient edit form 

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #460 
