### PR TITLE
change sandbox url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/colinxfleming/dcaf_case_management/branch/master/graph/badge.svg)](https://codecov.io/gh/colinxfleming/dcaf_case_management)
 [![](https://images.microbadger.com/badges/image/colinxfleming/dcaf_case_management.svg)](https://microbadger.com/images/colinxfleming/dcaf_case_management "Get your own image badge on microbadger.com")
 
-[A deployed demo version of what's in the master branch is at: http://dcaf-cmapp-staging.herokuapp.com/](http://dcaf-cmapp-staging.herokuapp.com/)
+[A deployed demo version of what's in the master branch is at: https://sandbox.dcabortionfund.org/](https://sandbox.dcabortionfund.org/)
 
 
 ## Next major project milestone: April 1: Launch to Baltimore!

--- a/civic.json
+++ b/civic.json
@@ -3,7 +3,7 @@
     "description": "A Rails-based case management system for ", 
     "license": "MIT", 
     "status": "Production", 
-    "homepage": "http://dcaf-cmapp-staging.herokuapp.com", 
+    "homepage": "https://sandbox.dcabortionfnd.org", 
     "repository": "https://github.com/colinxfleming/dcaf_case_management", 
     "type": "Web App", 
     "thumbnail": "", 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Due to changes in #829 we've got a new sandbox URL with a LetsEncrypt SSL certificate. Those changes are deployed in staging; this makes associated changes to the readme and civic to reflect the new domain of the sandbox env.
