### PR TITLE
Remove Undocumented from view

### DIFF
--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -94,8 +94,6 @@
                               checked: patient.special_circumstances.include?('Incest'), namespace: 'Incest' }, 'Incest', '' %>
             <%= f.check_box :special_circumstances, { label: 'Prison', name: 'patient[special_circumstances][]',
                               checked: patient.special_circumstances.include?('Prison'), namespace: 'Prison' }, 'Prison', '' %>
-            <%= f.check_box :special_circumstances, { label: 'Undocumented', name: 'patient[special_circumstances][]',
-                              checked: patient.special_circumstances.include?('Undocumented'), namespace: 'Undocumented' }, 'Undocumented', '' %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removes Undocumented as an option from app

This pull request makes the following changes:
* Removes option from frontend in `app/views/patients/_patient_information.html.erb`

To remove references to "Undocumented":
* `rails console`
    - `Patient.all.pull(special_circumstances: "Undocumented")`

It relates to the following issue #s: 
* Fixes #834 
