### PR TITLE
Adjust visited links color

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -19,7 +19,11 @@ $font-size: 17px;
   .navbar-header > a, .navbar-nav > li > a, .navbar-link{
     color: $dcaf-color;
     &:hover{
-      color: lighten($dcaf-color, 20%)
+      color: lighten($dcaf-color, 20%);
+      text-decoration: underline;
+    }
+    &:visited{
+      color: #0B0BF6;
     }
   }
 }
@@ -82,6 +86,18 @@ $font-size: 17px;
 .btn-lg {
   margin: 15px 0;
   padding: 15px 30px;
+}
+
+// Global links
+.container {
+  a {
+    &:hover {
+      text-decoration: underline;
+    }
+    &:visited {
+      color: #0B0BF6;
+    }
+  }
 }
 
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -23,7 +23,7 @@ $font-size: 17px;
       text-decoration: underline;
     }
     &:visited{
-      color: #0B0BF6;
+      color: #000080;
     }
   }
 }
@@ -87,19 +87,6 @@ $font-size: 17px;
   margin: 15px 0;
   padding: 15px 30px;
 }
-
-// Global links
-.container {
-  a {
-    &:hover {
-      text-decoration: underline;
-    }
-    &:visited {
-      color: #0B0BF6;
-    }
-  }
-}
-
 
 // General styling artifacts
 // make all images responsive by default


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Jumps off @AlexandraCasser 's great CSS work in #843 -- mostly just removing some global styles and setting a darker shade of blue.

This pull request makes the following changes, all implemented by @AlexandraCasser :
* Underline links on hover
* Navy blue after visited

It relates to the following issue #s: 
* Fixes #783 
