### PR TITLE
Remove second Login with Google link

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -18,8 +18,8 @@
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
-  <% end -%>
-<% end -%>
+<%#- if devise_mapping.omniauthable? %>
+  <%#- resource_class.omniauth_providers.each do |provider| %>
+    <%#= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+  <%# end -%>
+<%# end -%>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Just removes the redundant link for signing in with Google.

This pull request makes the following changes:
* Comment out loop in app/views/devise/shared/_links.html.erb. Left in code in case more options are added in the future and it becomes useful for some reason.

![screen shot 2017-02-15 at 2 03 05 pm](https://cloud.githubusercontent.com/assets/5544326/22999399/95a401a2-f387-11e6-8396-dcc39a4ca0de.png)

It relates to the following issue #s: 
* Fixes #819 
