### PR TITLE
Allow for automated tests to be run in specific suites

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,35 @@ Rails.application.load_tasks
 task clear_call_lists: :environment do
   User.all.each(&:clear_call_list)
 end
+
+Rake::Task['test:run'].clear
+Rake::Task['test:integration'].clear
+# Uncomment when throttling tests go live
+# Rake::Task['test:middleware'].clear
+
+namespace :test do
+  Rails::TestTask.new(:limited) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/**/*_test.rb'].exclude(
+      'test/integration/**/*_test.rb'
+      )
+  end
+
+  Rails::TestTask.new(:everything) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/**/*_test.rb']
+  end
+
+  Rails::TestTask.new('integration' => 'test:prepare') do |t|
+    t.libs << 'test'
+    t.pattern = 'test/integration/**/*_test.rb'
+  end
+
+  # Allows for middleware to be tested separately
+  #Rails::TestTask.new('middleware' => 'test:prepare') do |t|
+    #t.libs << 'test'
+    #t.pattern = 'test/middleware/**/*_test.rb'
+  #end
+
+  task :run => ['test:limited', 'test:integration']
+end

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ deployment:
 
 test:
   override:
-    - bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS":
+    - bundle exec rake test:everything TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS":
         parallel: true
         files:
           - test/**/*_test.rb


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This allows for rake tests to be run in a variety of ways, and switches default behavior:
* `rake test` will still run everything, but it can be modified to drop a specific suite if need be
* `rake test:everything` is now an implicit command to run ALL tests
* `rake test:limited` excludes integration tests
* `rake test:middleware` would run only the middleware tests (currently commented out) 

The end result of this is some narrow tests that could be laborious in nature can be moved to only running under CI.

This pull request makes the following changes:
* Modifications to Rakefile
* Small tweak to circle.yml to use `rake test:everything`

It relates to the following issue #s: 
* Fixes #849 
* Mildly related to #820 
