### PR TITLE
Initial changes to support data volunteers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User
   # Non-devise generated
   field :name, type: String
   field :line, type: String
-  enum :role, [:cm, :admin]
+  enum :role, [:cm, :admin, :data_volunteer]
   field :call_order, type: Array
 
   ## Database authenticatable

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -7,7 +7,7 @@
     <li><%= link_to 'Notes', '#notes', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Change Log', '#change_log', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Call Log', '#call_log', data: { toggle: 'tab' } %></li>
-    <% if current_user.admin? && patient.pregnancy.pledge_sent == true %>
+    <% if ( current_user.admin? || current_user.data_volunteer? ) && patient.pregnancy.pledge_sent == true %>
       <li><%= link_to 'Pledge Fulfillment', '#fulfillment', data: { toggle: 'tab' } %></li>
     <% end %>        
 

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -19,7 +19,7 @@
     <%= render 'patients/change_log', patient: @patient %>
     <%= render 'patients/call_log', patient: @patient %>
     <%= render 'patients/notes', patient: @patient, note: @note %>
-    <% if current_user.admin? && @patient.pregnancy.pledge_sent == true %>
+    <% if ( current_user.admin? || current_user.data_volunteer? ) && @patient.pregnancy.pledge_sent == true %>
       <%= render 'patients/fulfillment', patient: @patient %>
     <% end %>  
   </div>

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -77,6 +77,23 @@ class CreateUserTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'data volunteer user' do
+    before do
+      @user = create :user, role: :data_volunteer
+      log_in_as @user
+    end
+
+    it 'should not show add user button' do
+      assert_no_text 'Create User'
+    end
+
+    it 'should redirect to root path if navigate to form' do
+      assert_not @user.admin?
+      visit new_user_path
+      assert_equal current_path, root_path
+    end
+  end
+
   describe 'not logged in' do
     it 'should show nothing if not logged in' do
       visit new_user_path

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -5,6 +5,7 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
     Capybara.current_driver = :poltergeist
     @user = create :user, role: :cm
     @admin = create :user, role: :admin
+    @data_volunteer = create :user, role: :data_volunteer
     @patient = create :patient, clinic_name: 'Nice Clinic',
                                 appointment_date: 2.weeks.from_now
     @pregnancy = create :pregnancy, patient: @patient,
@@ -38,7 +39,38 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
       visit edit_patient_path @patient
     end
 
+    after do
+      sign_out
+    end
+
     it 'should not show the fulfillment link to an admin unless pledge sent' do
+      refute has_text? 'Pledge Fulfillment'
+      refute has_link? 'Pledge Fulfillment'
+    end
+
+    it 'should show a link to the pledge fulfillment tab after pledge sent' do
+      find('#submit-pledge-button').click
+      find('#submit-pledge-to-p2').click
+      find('#submit-pledge-to-p3').click
+      check 'I sent the pledge'
+      find('#submit-pledge-finish').click
+      visit authenticated_root_path
+      visit edit_patient_path @patient
+
+      assert has_link? 'Pledge Fulfillment'
+      click_link 'Pledge Fulfillment'
+      assert has_text? 'Procedure date'
+      assert has_text? 'Check #'
+    end
+  end
+
+  describe 'visiting the edit patient view as a data volunteer' do
+    before do
+      log_in_as @data_volunteer
+      visit edit_patient_path @patient
+    end
+
+    it 'should not show the fulfillment link to a data_volunteer unless pledge sent' do
       refute has_text? 'Pledge Fulfillment'
       refute has_link? 'Pledge Fulfillment'
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This allows for data volunteer users to be created. 

This pull request makes the following changes:
* Thus far all implementation details are in #855 minus a typo (added enum to users not patients)

It relates to the following issue #s: 
* Fixes #855 
