### PR TITLE
Fix db/seeds.rb to fail loudly on DB errors

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,18 +16,18 @@ User.destroy_all
 #                         password: 'P4ssword', password_confirmation: 'P4ssword'
 
 # Create two test users
-user = User.create name: 'testuser (admin)', email: 'test@test.com',
+user = User.create! name: 'testuser (admin)', email: 'test@test.com',
                    password: 'P4ssword', password_confirmation: 'P4ssword',
                    role: :admin
-user2 = User.create name: 'testuser2', email: 'test2@test.com',
+user2 = User.create! name: 'testuser2', email: 'test2@test.com',
                     password: 'P4ssword', password_confirmation: 'P4ssword'
-user3 = User.create name: 'testuser3', email: 'dcaf.testing@gmail.com',
+user3 = User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
                     password: 'P4ssword', password_confirmation: 'P4ssword'
 
 # Create ten patients
 10.times do |i|
   flag = i.even? ? true : false
-  Patient.create name: "Patient #{i}",
+  Patient.create! name: "Patient #{i}",
                  primary_phone: "123-123-123#{i}",
                  initial_call_date: 3.days.ago,
                  urgent_flag: flag,
@@ -69,7 +69,7 @@ Patient.all.each do |patient|
 
   # Add example of patient with other contact info
   if patient.name == 'Patient 1'
-    patient.update name: "Other Contact info - 1", other_contact: "Jane Doe",
+    patient.update! name: "Other Contact info - 1", other_contact: "Jane Doe",
                    other_phone: "234-456-6789", other_contact_relationship: "Sister"
     patient.calls.create! status: 'Reached patient',
                           created_at: 14.hours.ago,
@@ -78,35 +78,35 @@ Patient.all.each do |patient|
 
   # Add example of patient with appointment one week from today && clinic selected
   if patient.name == 'Patient 2'
-    patient.update name: "Clinic and Appt - 2",
+    patient.update! name: "Clinic and Appt - 2",
                     clinic_name: "Sample Clinic 1",
-                    appointment_date: 1.week.from_now
+                    appointment_date: (1.week.from_now)
   end
 
   # Add example of patient with a pledge submitted
   if patient.name == 'Patient 3'
-    patient.pregnancy.update naf_pledge: 2000,
+    patient.pregnancy.update! naf_pledge: 2000,
                              procedure_cost: 4000,
                              procedure_date: 1.week.from_now,
                              dcaf_soft_pledge: 1000,
                              pledge_sent: true,
                              patient_contribution: 1000,
                              created_by: user2
-    patient.update name: "Pledge submitted - 3",
+    patient.update! name: "Pledge submitted - 3",
                    clinic_name: "Sample Clinic 1", 
                    appointment_date: 10.days.from_now
   end
 
   # Add example of patient should have special circumstances
   if patient.name == 'Patient 4'
-    patient.update name: "Special Circumstances - 4",
+    patient.update! name: "Special Circumstances - 4",
                    special_circumstances: ["Prison", "Fetal anomaly"]
   end
 
   # Add example of patient should be marked resolved without DCAF
   if patient.name == 'Patient 5'
-    patient.pregnancy.update resolved_without_dcaf: true
-    patient.update name: "Resolved without DCAF - 5"
+    patient.pregnancy.update! resolved_without_dcaf: true
+    patient.update! name: "Resolved without DCAF - 5"
   end
 
   patient.save
@@ -138,7 +138,7 @@ end
 patient_in_completed_calls = 
   Patient.find_by name: 'Special Circumstances - 4'
 user.add_patient patient_in_completed_calls
-patient_in_completed_calls.calls.create status: 'Left voicemail',
+patient_in_completed_calls.calls.create! status: 'Left voicemail',
                                         created_by: user
 
 # Log results

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,8 @@ Patient.all.each do |patient|
 
   # Add example of patient with a pledge submitted
   if patient.name == 'Patient 3'
+    patient.update! clinic_name: "Sample Clinic 1",
+                    appointment_date: 10.days.from_now
     patient.pregnancy.update! naf_pledge: 2000,
                              procedure_cost: 4000,
                              procedure_date: 1.week.from_now,
@@ -92,9 +94,7 @@ Patient.all.each do |patient|
                              pledge_sent: true,
                              patient_contribution: 1000,
                              created_by: user2
-    patient.update! name: "Pledge submitted - 3",
-                   clinic_name: "Sample Clinic 1", 
-                   appointment_date: 10.days.from_now
+    patient.update! name: "Pledge submitted - 3"
   end
 
   # Add example of patient should have special circumstances


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

When poking around at Date formats, I noticed my `rake db:seed` was failing to find a patient after their name was updated, implying the update failed silently. Upon examining the `db/seeds.rb` file, I found the `create` and `update` methods are often called without a following `!`. When running in `rake db:seed`, you need to call `create!` or `update!` for any failure to happen loudly,

This pull request makes the following changes:
* `db/seeds.rb` all `create` calls are now `create!`
* `db/seeds.rb` all `update` calls are now `update!`
* `db/seeds.rb` test `Add example of patient with a pledge submitted` now functional
   * `Patient`s are required to have a `clinic_name` and `appointment_date` prior to pledge submission, so that update was moved to happen _before_ the pledge submit line (see lines 86-98) 

Not related to any issue, found while poking around in date format changes and how it affects the seeds file.

Submitted as two commits to illuminate the issue:
* first commit adds the `create!` and `update!` calls, making the `rake db:seed` call fail loudly at the bad update call.
* second commit fixes the failing seed