### PR TITLE
Issue #448 - move notes expander to own column for alignment

### DIFF
--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -16,6 +16,7 @@
         <th>Notes</th>
         <th></th>
         <th></th>
+        <th></th>
       </tr>
     </thead>
     <tbody id="<%= table_type %>_content">
@@ -29,8 +30,8 @@
           <td><%= patient.pregnancy.last_menstrual_period_display_short %></td>
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date %></td>
-          <td><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
-
+          <td><%= patient.most_recent_note_display_text %></td>
+          <td><%= plus_sign_glyphicon(patient.most_recent_note) %></td>
           <% if table_type == 'completed_calls' || table_type == 'urgent_patients' %>
             <td class="blank-td"></td>
           <% else %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
Break plus sign icon for notes expander into its own column to fix alignment issue
![screen shot 2017-02-22 at 3 43 59 pm](https://cloud.githubusercontent.com/assets/11983227/23238208/c211a6fc-f915-11e6-9a75-9880cd2c4af5.png)
e know what to look for!)

It relates to the following issue #s: 
* https://github.com/colinxfleming/dcaf_case_management/issues/448
