### PR TITLE
Test fluke after 4:00 Pacific time - fixed date display

### DIFF
--- a/test/integration/table_content_test.rb
+++ b/test/integration/table_content_test.rb
@@ -28,7 +28,7 @@ class TableContentTest < ActionDispatch::IntegrationTest
       within :css, '#call_list_content' do
         assert has_content? @patient.primary_phone_display
         assert has_content? @patient.name
-        assert has_content? 3.days.from_now.utc.display_date
+        assert has_content? 3.days.from_now.utc.strftime('%Y-%m-%d')
         assert has_content? @patient.pregnancy.last_menstrual_period_display_short
         # TODO: has remove, phone clicky
       end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
When running the test suite, I noticed that it started flaking after 4:00 p.m. PST. It appears to be how the display_date method was called in the test suite - it converted it out of UTC time. I changed it to use .strftime, so it should work correctly at any time now.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
I didn't see an issue for this, just noticed it while running the test suite.
