### PR TITLE
Tidy issue template, shift setup instructions into one place

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -4,6 +4,6 @@ Thanks for creating an issue! Please fill out this form so we can be sure to hav
 
 * **What feature or behavior is this required for?**
 
-* **How should we solve this issue?**
+* **How could we solve this issue? (Not knowing is okay!)**
 
 * **Anything else?**

--- a/README.md
+++ b/README.md
@@ -74,13 +74,11 @@ We also keep track of our administrative issues and discussion in Github under t
 
 ## Setting Stuff Up
 
-* **First things first**: Make a copy of your own to wrench on by forking! Go to https://github.com/colinxfleming/dcaf_case_management and hit the `fork` button up in the top right.
-* **Second things second**: `git clone https://github.com/{YOUR GITHUB USERNAME}/dcaf_case_management` to pull it down to your local system
-* **Third things third**: Add the source repo as the upstream with the command `git remote add upstream https://github.com/colinxfleming/dcaf_case_management`. This will let you update when the source repo changes by running the command `git pull upstream master`.
+[We have detailed instructions on how to get started here!](docs/SETUP.md)
 
-For the rest of the setup, you have three options: Docker, installing everything locally, or Cloud9. We recommend Docker if you're comfortable with its ecosystem.
+If you have any trouble getting things set up, please ping us in Slack!
 
-For detailed instructions on how to get the code running, including Rails and MongoDB, please refer to [our setup documentation](docs/SETUP.md).
+If you see a spot in the docs that's confusing or could be improved, please pay it forward by making a pull request!
 
 
 ## For designers (Team lead: @mebates, user testing lead: @eheintzelman)

--- a/docs/GOOGLE_SIGN_ON_SETUP.md
+++ b/docs/GOOGLE_SIGN_ON_SETUP.md
@@ -1,5 +1,7 @@
 # Setting up Google SSO
 
+## SHORT VERSION: Unless you need to make a fix to the SSO, you don't need to do this and can log in with a regular password. See `db/seeds.rb` for login creds in development
+
 To avoid password related weaknesses, we give our case managers the opportunity to use their google accounts to sign in. Password authentication still works, so you can avoid this completely and it's fine.
 
 Setting it up requires a few more hoops to jump through. You'll need to acquire a few keys from @colinxfleming or @DarthHater and then do the following:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,6 +2,11 @@
 
 The directions below get you to a point where you can run the app with a test-seeded database.
 
+* **First things first**: Make a copy of your own to wrench on by forking! Go to https://github.com/colinxfleming/dcaf_case_management and hit the `fork` button up in the top right.
+* **Second things second**: `git clone https://github.com/{YOUR GITHUB USERNAME}/dcaf_case_management` to pull it down to your local system
+* **Third things third**: Add the source repo as the upstream with the command `git remote add upstream https://github.com/colinxfleming/dcaf_case_management`. This will let you update when the source repo changes by running the command `git pull upstream master`.
+
+For the rest of the setup, you have three options: Docker, installing everything locally, or Cloud9. We recommend Docker if you're comfortable with its ecosystem.
 
 ## Docker
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Two improvements here:
* Per suggestion from the very wise @lomky , changes the 'should' to 'could' in the issue template
* Per suggestion from the very wise @ashlynnpai , moves all the setup instructions to one place

It relates to the following issue #s: 
* Fixes #875 
