### PR TITLE
[#845] limit patient results returned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'shoulda-context'
   gem 'minitest-reporters'
   gem 'mini_backtrace'
   gem 'minitest-spec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,7 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     sexp_processor (4.7.0)
+    shoulda-context (1.2.2)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -454,6 +455,7 @@ DEPENDENCIES
   ruby_audit
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-context
   simplecov
   spring
   timecop
@@ -466,4 +468,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.3
+   1.14.4

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -7,6 +7,7 @@ class Patient
   include Mongoid::Userstamp
   include StatusHelper
 
+  SEARCH_LIMIT = 15
   LINES.each do |line|
     scope line.downcase.to_sym, -> { where(:_line.in => [line]) }
   end
@@ -215,10 +216,18 @@ class Patient
       all_matching_names = find_name_matches name_regexp, lines
       all_matching_phones = find_phone_matches phone_regexp, lines
 
-      (all_matching_names | all_matching_phones)
+      sort_and_limit_patient_matches(all_matching_names, all_matching_phones)
     end
 
     private
+
+
+    def sort_and_limit_patient_matches(all_matching_names, all_matching_phones)
+      matches = (all_matching_names | all_matching_phones)
+      matches.sort{|a,b|
+        b.updated_at <=> a.updated_at
+      }.first(SEARCH_LIMIT)
+    end
 
     def find_name_matches(name_regexp, lines = LINES)
       if nonempty_regexp? name_regexp

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -215,16 +215,19 @@ class Patient
 
       all_matching_names = find_name_matches name_regexp, lines
       all_matching_phones = find_phone_matches phone_regexp, lines
+      all_matching_identifiers = find_identifier_matches(identifier_regexp)
 
-      sort_and_limit_patient_matches(all_matching_names, all_matching_phones)
+      sort_and_limit_patient_matches(all_matching_names, all_matching_phones, all_matching_identifiers)
     end
 
     private
 
 
-    def sort_and_limit_patient_matches(all_matching_names, all_matching_phones)
-      matches = (all_matching_names | all_matching_phones)
-      matches.sort{|a,b|
+    def sort_and_limit_patient_matches(*matches)
+      all_matches = matches.reduce{ |results, matches_of_type|
+        results | matches_of_type
+      }
+      all_matches.sort { |a,b|
         b.updated_at <=> a.updated_at
       }.first(SEARCH_LIMIT)
     end
@@ -238,8 +241,8 @@ class Patient
       []
     end
 
-    def find_identfier_matches(identifier_regexp)
-      if nonempty_regexp? identifier
+    def find_identifier_matches(identifier_regexp)
+      if nonempty_regexp? identifier_regexp
         identifier = Patient.where identifier: identifier_regexp
         return identifier
       end

--- a/test/integration/call_list_test.rb
+++ b/test/integration/call_list_test.rb
@@ -124,7 +124,7 @@ class CallListTest < ActionDispatch::IntegrationTest
     fill_in 'search', with: patient.name
     wait_for_element 'Search results'
     click_button 'Search'
-    find('a', text: 'Add').click
+    find('a', text: 'Add', wait: 5).click
     wait_for_ajax
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -150,6 +150,10 @@ class PatientTest < ActiveSupport::TestCase
       assert_equal 1, Patient.search('Friend Ship').count
     end
 
+    it 'can find multiple patients off an identifier' do
+      assert_same_elements [@pt_1, @pt_2], Patient.search('D1-24')
+    end
+
     # it 'should find multiple patients if there are multiple' do
     #   assert_equal 2, Patient.search('124-456-6789').count
     # end
@@ -187,10 +191,6 @@ class PatientTest < ActiveSupport::TestCase
     # spotty test?
     it 'should be able to find based on phone patterns' do
       assert_equal 2, Patient.search('124').count
-    end
-
-    it 'should be able to find based on identifier' do
-      assert_equal 1, Patient.search('D9-9999').count
     end
 
     it 'should be able to narrow on line' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -154,6 +154,32 @@ class PatientTest < ActiveSupport::TestCase
     #   assert_equal 2, Patient.search('124-456-6789').count
     # end
 
+    describe 'order' do
+
+      before do
+        Timecop.freeze Date.new(2014,4,4)
+        @pt_4.update! name: 'Laila C.'
+        Timecop.freeze Date.new(2014,4,5)
+        @pt_3.update! name: 'Laila B.'
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it 'should return patients in order of last modified' do
+        assert_equal [@pt_3, @pt_4], Patient.search('Laila')
+      end
+
+      it 'should limit the number of patients returned' do
+        16.times do |num|
+          create :patient, primary_phone: "124-567-78#{num+10}"
+        end
+        assert_equal 15, Patient.search('124').count
+      end
+
+    end
+
     it 'should be able to find based on secondary phones too' do
       assert_equal 1, Patient.search('999-999-9999').count
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds a limit to the number of patient search results being returned.

This pull request makes the following changes:
-> adds a limit and ability to sort the search results coming back.
(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #845 

Notes:
I didn't know how to deal with the fact updated_at can't be accessed directly in mongo, so if you've got a better way to test the sorting, please let me know!

Staring at the current search functionality, I opted to not try and figure out how to make it AREL-y, since the two different main functions at play find_name_matches and find_phone_matches, aren't either.