### PR TITLE
add change line functionality for admins

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -25,6 +25,10 @@ module PatientsHelper
      'No insurance', 'Don\'t know', 'Other (add to notes)']
   end
 
+  def line_options
+    ['DC', 'MD', 'VA']
+  end
+
   def income_options
     [nil,
      ['Under $9,999 ($192/wk - $833/mo)', 'Under $9,999'],

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -9,6 +9,12 @@
 
       <div class="row">
         <div class="info-form-left col-sm-6">
+          <% if current_user.admin? %>
+            <%= f.select :line,
+                       options_for_select(line_options,
+                                          patient.line),
+                                          label: 'Line' %>
+          <% end %>
           <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
           <%= f.select :race_ethnicity,
                        options_for_select(race_ethnicity_options,
@@ -75,6 +81,8 @@
                        options_for_select(referred_by_options,
                                           patient.referred_by),
                                           autocomplete: 'off' %>
+
+
 
           <p style="font-weight:bold">Special circumstances</p>
           <%= f.form_group :special_circumstances do %>

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -134,9 +134,33 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_checked_field? 'Spanish Only'
         assert has_checked_field? 'Homelessness'
         assert has_checked_field? 'Prison'
+        assert has_no_css? '#patient_line'
+      end
+    end
+
+    # for changing a patient's line
+    describe 'changing ADMIN patient information' do
+      before do
+        @user.update role: :admin
+        click_link 'Patient Information'
+        visit edit_patient_path @patient
+
+        select 'MD', from: 'patient_line'
+
+        click_away_from_field
+        wait_for_ajax
+
+        reload_page_and_click_link 'Patient Information'
+      end
+
+      it 'should alter the information' do
+        within :css, '#patient_information' do
+          assert_equal 'MD', find('#patient_line').value
+        end
       end
     end
   end
+
 
   describe 'changing fulfillment information' do
     before do
@@ -157,6 +181,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       select '12 weeks', from: 'Weeks along at procedure'
       fill_in 'Abortion care $', with: '100'
       fill_in 'Check #', with: '444-22'
+
       click_away_from_field
       wait_for_ajax
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a line dropdown box for admins

This pull request makes the following changes:
* Adds line dropdown on patient information tab.
* Checks if line option is visible for non-admins and for admins

Uploading images not working on github.

It relates to the following issue #s: 
* Fixes #868
