### PR TITLE
Remove HTML safes

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,17 +1,24 @@
 module NotesHelper
   def plus_sign_glyphicon(note)
     return nil unless note && note.try(:full_text).length > 31
-    "<span class='glyphicon glyphicon-plus-sign' aria-hidden='true' " \
-    "data-toggle='popover' data-placement='bottom' title='Most recent note' " \
-    "data-content='#{h note.full_text}'>" \
-    "</span><span class='sr-only'>Full note</span>".html_safe
+    note = tag(:span, class: 'glyphicon glyphicon-plus-sign',
+                      title: 'Most recent note',
+                      aria: { hidden: true },
+                      data: { toggle: 'popover', placement: 'bottom',
+                              content: note.full_text })
+    sr = tag(:span, class: 'sr-only', text: 'Full note')
+    safe_join([note, sr], '')
   end
 
   def display_note_text_for(note)
     return nil unless note.try(:full_text).present?
-
-    "<p><strong>Most recent note from #{h note.created_by.name} " \
-    "at #{note.created_at.display_timestamp}:</strong></p>" \
-    "<p>#{h note.full_text[0..400]}</p>".html_safe
+    info = content_tag :p do
+      content_tag(:strong) do
+        "Most recent note from #{note.created_by.name} " \
+        "at #{note.created_at.display_timestamp}:"
+      end
+    end
+    text = content_tag(:p) { note.full_text[0..400] }
+    safe_join([info, text], '')
   end
 end

--- a/app/helpers/pledges_helper.rb
+++ b/app/helpers/pledges_helper.rb
@@ -1,0 +1,9 @@
+module PledgesHelper
+  def submit_pledge_button
+    content_tag :span, class: 'btn btn-primary btn-lg submit-btn btn-block',
+                       aria: { hidden: true },
+                       id: 'submit-pledge-button' do
+      'Submit pledge'
+    end
+  end
+end

--- a/app/helpers/welcome_message_helper.rb
+++ b/app/helpers/welcome_message_helper.rb
@@ -10,7 +10,6 @@ module WelcomeMessageHelper
     [
       'Thank you! - Team CM',
       'You are making choice a reality for the people you serve.',
-      "<img src='http://placekitten.com/300/300' />",
       "Keep up the good work, you're doing great!",
       "We're all rooting for you!"
     ]

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,5 +29,5 @@
 </div>
 
 <div class="col-sm-6">
-  <h2><%= random_welcome_message.html_safe %></h2>
+  <h2><%= random_welcome_message %></h2>
 </div>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -1,6 +1,4 @@
 <section class="abortion-left-menu">
-  <!-- links to hook into forms on right side -->
-
   <ul class="nav nav-pills nav-stacked">
     <li class='active'><%= link_to 'Patient Information', '#patient_information', data: { toggle: 'tab' } %></li>
     <li><%= link_to 'Abortion Information', '#abortion_information', data: { toggle: 'tab' } %></li>
@@ -14,12 +12,7 @@
   </ul>
   <div class="row">
     <div class="col-sm-10">
-      <%#= f.submit 'TEMP: SAVE INFORMATION', class: 'btn btn-primary btn-block' %>
-
-<%= link_to "<span class='btn btn-primary btn-lg submit-btn btn-block' aria-hidden='true' id='submit-pledge-button'>Submit pledge</span>".html_safe, '#pledge-modal', class: "submit-pledge-button", data: {toggle: "modal"} %>
-
+      <%= link_to submit_pledge_button, '#pledge-modal', class: 'submit-pledge-button', data: { toggle: 'modal' } %>
     </div>
   </div>
 </section>
-
-<!-- Need to add glyphicon-chevron-right before li.active -->

--- a/test/helpers/pledges_helper_test.rb
+++ b/test/helpers/pledges_helper_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class PledgesHelperTest < ActionView::TestCase
+  describe 'convenience methods' do
+    describe 'submit_pledge_button' do
+      it 'should return a span tag' do
+        assert_match /span/, submit_pledge_button
+        assert_match /Submit pledge/, submit_pledge_button
+      end
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Moves a bunch of stuff we were generating with HTML safe into content tags.

This pull request makes the following changes:
* Does what it says on the label
* Removes the cat picture from the welcome messages, since placekitten is busted

It relates to the following issue #s: 
* Fixes #885 
