### PR TITLE
Remove calendar icon from datepicker fields

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -17,7 +17,7 @@
         </div>  
         <div class="info-form-left col-sm-6">
           <%= f.fields_for patient.fulfillment do |pt| %>
-            <%= pt.datetime_picker :procedure_date, 
+            <%= pt.text_field :procedure_date,
                                   label: 'Procedure date',
                                   autocomplete: 'off', format: '%Y-%m-%d',
                                   placeholder: 'YYYY-MM-DD' %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -24,7 +24,7 @@
 
   <div class="col-sm-4">
     <div class="row">
-      <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD', help: "Approx gestation at appt: #{patient.pregnancy.last_menstrual_period_at_appt}" %>
+      <%= f.text_field :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD', help: "Approx gestation at appt: #{patient.pregnancy.last_menstrual_period_at_appt}" %>
     </div>
   </div>
 <% end %>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -42,7 +42,7 @@
   <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), label: 'Race / Ethnicity', autocomplete: 'off' %>
   <%= f.select :clinic_name, options_for_select(clinic_options) %>
 
-  <%= f.datetime_picker :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD' %>
+  <%= f.text_field :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD' %>
 
   <%= f.select :insurance,
                options_for_select(insurance_options),


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I removed the calendar icon from all date picker fields, even though the issue only mentioned the appointment date field. I couldn't figure out where the data_entry template is used (maybe it's not used anymore?), but it should work.

<img width="409" alt="screen shot 2017-03-04 at 12 06 39 pm" src="https://cloud.githubusercontent.com/assets/7842799/23581897/078efd3c-00d3-11e7-8b5d-349e68af3740.png">

It relates to the following issue #s: 
* Fixes #660 