### PR TITLE
Add referred_to_clinic field to track referrals

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -77,8 +77,8 @@ class PatientsController < ApplicationController
       clinic: [:id, :name, :street_address_1, :street_address_2,
                :city, :state, :zip],
       pregnancy: [:last_menstrual_period_days, :last_menstrual_period_weeks,
-                  :resolved_without_dcaf, :procedure_cost, :pledge_sent,
-                  :patient_contribution, :naf_pledge, :dcaf_soft_pledge],
+                  :resolved_without_dcaf, :referred_to_clinic, :procedure_cost,
+                  :pledge_sent, :patient_contribution, :naf_pledge, :dcaf_soft_pledge],
       special_circumstances: [],
       fulfillment: [:fulfilled, :procedure_date, :gestation_at_procedure,
                     :procedure_cost, :check_number, :check_date]

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -23,6 +23,7 @@ class Pregnancy
   field :procedure_date, type: DateTime
   field :procedure_completed_date, type: DateTime
   field :resolved_without_dcaf, type: Boolean
+  field :referred_to_clinic, type: Boolean
 
   # Temp fields associated with pledges: TEMPORARY
   field :patient_contribution, type: Integer

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -22,6 +22,9 @@
                 <%= pt.form_group :resolved_without_dcaf, label: { text: 'Resolved without assistance from DCAF' } do %>
                   <%= pt.check_box :resolved_without_dcaf, label: '' %>
                 <% end %>
+                <%= pt.form_group :referred_to_clinic, label: { text: 'Referred to clinic' } do %>
+                  <%= pt.check_box :referred_to_clinic, label: '' %>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -53,6 +53,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       click_link 'Abortion Information'
       select 'Sample Clinic 1', from: 'patient_clinic_name'
       check 'Resolved without assistance from DCAF'
+      check 'Referred to clinic'
 
       fill_in 'Abortion cost', with: '300'
       fill_in 'Patient contribution', with: '200'
@@ -69,7 +70,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     it 'should alter the information' do
       within :css, '#abortion_information' do
         assert_equal 'Sample Clinic 1', find('#patient_clinic_name').value
-        assert_equal '1', find('#patient_pregnancy_resolved_without_dcaf').value
+        assert has_checked_field?('Resolved without assistance from DCAF')
+        assert has_checked_field?('Referred to clinic')
         # TODO: review after getting clinic logic in place
 
         assert has_field? 'Abortion cost', with: '300'


### PR DESCRIPTION
This PR adds referred_to_clinic field to track referrals :white_check_mark:

This pull request makes the following changes:
* Adds `referred_to_clinic` boolean to Pregnancy model & strong params on PatientsController
* Adds a "Referred to clinic" checkbox to the Clinic Details section of Abortion Information
* Tests that the checkbox works! Also fixes the test for the "Resolved without assistance from DCAF" checkbox, which was incorrectly passing.

Here's what it looks like:
![screen shot 2017-03-04 at 2 58 21 pm](https://cloud.githubusercontent.com/assets/978428/23582925/0af6adb8-00eb-11e7-838d-dd985bed4e55.png)

It relates to the following issue #s: 
* Fixes #897

