### PR TITLE
Adjust status helper for rare scenario

### DIFF
--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -12,9 +12,9 @@ module StatusHelper
   def status
     return STATUSES[:resolved] if pregnancy.resolved_without_dcaf?
     return STATUSES[:pledge_sent] if pregnancy.pledge_sent?
+    return STATUSES[:no_contact] if not contact_made?
     return STATUSES[:fundraising] if appointment_date
-    return STATUSES[:needs_appt] if contact_made?
-    STATUSES[:no_contact]
+    STATUSES[:needs_appt]
   end
 
   private

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -8,7 +8,7 @@ class StatusHelperTest < ActionView::TestCase
     @pregnancy = create :pregnancy, patient: @patient
   end
 
-  describe 'status method' do
+  describe 'status method branch 1' do
     it 'should default to "No Contact Made" when a patient has no calls' do
       assert_equal Patient::STATUSES[:no_contact], @patient.status
     end
@@ -18,12 +18,20 @@ class StatusHelperTest < ActionView::TestCase
       assert_equal Patient::STATUSES[:no_contact], @patient.status
     end
 
+    it 'should still say "No Contact Made" if patient leaves voicemail with appointment' do
+      @patient.appointment_date = '01/01/2017'
+      assert_equal Patient::STATUSES[:no_contact], @patient.status
+    end
+  end
+
+  describe 'status method branch 2' do
     it 'should update to "Needs Appointment" once patient has been reached' do
       create :call, patient: @patient, status: 'Reached patient'
       assert_equal Patient::STATUSES[:needs_appt], @patient.status
     end
 
-    it 'should update to "Fundraising" once an appointment has been made' do
+    it 'should update to "Fundraising" once appointment made and patient reached' do
+      create :call, patient: @patient, status: 'Reached patient'
       @patient.appointment_date = '01/01/2017'
       assert_equal Patient::STATUSES[:fundraising], @patient.status
     end


### PR DESCRIPTION
There's an edge case where a PT calls in and leaves a voicemail
indicating they have an appointment date. If we then set the appointment
date in the system, the status would have been 'Fundraising' but in
reality we would prefer it to say 'No Contact Made'.

This fix adjusts the priority of the statuses slightly that No Contact
Made will come up if we haven't talked to a user yet, regardless of
their appointment status.

Fixes issue #676.

This pull request makes the following changes:
* Adjust status helper as above
* Adjust tests to test new behavior

It relates to the following issue #s: 
* Fixes #676 
