### PR TITLE
Add clinic & DCAF pledge amount to Pledge Fulfillment page

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -5,6 +5,11 @@
       <div class="row">
         <div class="col-sm-12">
           <h2>Pledge Fulfillment</h2>
+          <p>Please confirm that the clinic and pledge amounts are correct:</p>
+          <ul>
+            <li>Clinic: <%= @patient.clinic_name %></li>
+            <li>DCAF Pledge Amount: $<%= @patient.pregnancy.dcaf_soft_pledge %></li>
+          </ul>
         </div>
       </div>
       <div class="row">

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -62,6 +62,8 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
 
       assert has_link? 'Pledge Fulfillment'
       click_link 'Pledge Fulfillment'
+      assert has_text? 'Clinic: Nice Clinic'
+      assert has_text? 'DCAF Pledge Amount: $500'
       assert has_text? 'Procedure date'
       assert has_text? 'Check #'
     end


### PR DESCRIPTION
This pull request makes the following changes:
* Adds clinic name & DCAF soft pledge to the pledge fulfillment form for less short-term memory exhaustion when processing pledge fulfillment forms. :thinking: 

Here's what it looks like:

![screen shot 2017-03-04 at 3 26 58 pm](https://cloud.githubusercontent.com/assets/978428/23583098/5024f1fc-00ef-11e7-89b2-d9544626252c.png)

It relates to the following issue #s: 
* Fixes #905
