### PR TITLE
Calculate outstanding balances for abortion costs

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -2,13 +2,46 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-$(document).on "click", "#toggle-call-log", ->
-  $(".old-calls").toggleClass("hidden")
-  html = if $(".old-calls").hasClass("hidden") then "View all calls" else "Limit list"
-  $("#toggle-call-log").html(html)
+updateBalance = ->
+  if $("#patient_pregnancy_procedure_cost").val()
+    $(".outstanding-balance-ctn").removeClass('hidden')
+    $("#outstanding-balance").text('$' + calculateRemainder())
+  else
+    $(".outstanding-balance-ctn").addClass('hidden')
 
-$(document).on "change", ".edit_patient", ->
-  $(this).submit()
+calculateRemainder = ->
+  total = valueToNumber $("#patient_pregnancy_procedure_cost").val()
+  contributions = valueToNumber($("#patient_pregnancy_patient_contribution").val()) +
+                  valueToNumber($("#patient_pregnancy_naf_pledge").val()) +
+                  valueToNumber($("#patient_pregnancy_dcaf_soft_pledge").val()) +
+                  valueToNumber($(".external_pledge_amount").toArray().reduce (acc, next) ->
+                    acc + valueToNumber($(next).val())
+                  , 0)
+  total - contributions
 
-$(document).on "change", ".edit_external_pledge", ->
-  $(this).submit()
+valueToNumber = (val) ->
+  +val || 0
+
+ready = ->
+  $(document).on "click", "#toggle-call-log", ->
+    $(".old-calls").toggleClass("hidden")
+    html = if $(".old-calls").hasClass("hidden") then "View all calls" else "Limit list"
+    $("#toggle-call-log").html(html)
+
+  $(document).on "change", ".edit_patient", ->
+    $(this).submit()
+
+  $(document).on "change", ".edit_external_pledge", ->
+    $(this).submit()
+
+  $(document).on "change", "#abortion-information-form input, #external_pledges input", ->
+    updateBalance()
+
+  $(document).on "click", "#create-external-pledge", ->
+    # timeout to handle mongo updating and rails appending new field
+    setTimeout(updateBalance, 500)
+
+  if $("#patient_pregnancy_procedure_cost").val()
+    updateBalance()
+
+$(document).on 'ready page:load', ready

--- a/app/views/external_pledges/_edit.html.erb
+++ b/app/views/external_pledges/_edit.html.erb
@@ -1,5 +1,5 @@
 <% unless external_pledge.new_record? %>
   <%= bootstrap_form_for external_pledge, url: patient_external_pledge_path(patient, external_pledge), remote: true do |f| %>
-    <%= f.text_field :amount, prepend: '$', label: "#{external_pledge.source} pledge" %>
+    <%= f.number_field :amount, control_class: 'form-control external_pledge_amount', prepend: '$', label: "#{external_pledge.source} pledge" %>
   <% end %>
 <% end %>

--- a/app/views/external_pledges/_new.html.erb
+++ b/app/views/external_pledges/_new.html.erb
@@ -1,6 +1,6 @@
 <h5>Or, record a new external pledge:</h5>
 <%= bootstrap_form_for [patient, new_external_pledge], html: { id: 'new-external-pledge' }, remote: true do |f| %>
 	<%= f.select :source, available_pledge_source_options_for(patient) %>
-	<%= f.text_field :amount %>
-	<%= f.submit class: 'btn btn-primary' %>
+	<%= f.number_field :amount %>
+	<%= f.submit class: 'btn btn-primary', id: 'create-external-pledge' %>
 <% end %>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -42,16 +42,20 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <%= f.fields_for patient.pregnancy do |pt| %>
-              <%= pt.text_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
+              <%= pt.number_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
             <% end %>
+            <div class="info-form-left form-group outstanding-balance-ctn hidden">
+              <label class="control-label">Outstanding Balance</label>
+              <div id="outstanding-balance"></div>
+            </div>
           </div>
 
           <div class="col-sm-6">
             <div id="pledge-contributions">
               <%= f.fields_for patient.pregnancy do |pt| %>
-                <%= pt.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
-                <%= pt.text_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
-                <%= pt.text_field :dcaf_soft_pledge, label: 'DCAF pledge', autocomplete: 'off', prepend: '$' %>
+                <%= pt.number_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
+                <%= pt.number_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
+                <%= pt.number_field :dcaf_soft_pledge, label: 'DCAF pledge', autocomplete: 'off', prepend: '$' %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Calculation functions for the Abortion Information - Cost Details page
* Shows outstanding balance calculating the difference between abortion cost and patient contribution + organizational pledges
* Updated field types in Cost Details section to number (prevents letters and typos!)
* Only displays outstanding balance section if Abortion Cost is entered
* Outstanding is updated in the same way database updates happen (on focus out or enter)
* Aims to recalculate outstanding balance if a new source is added

(If there are changes to the views, please include a screenshot so we know what to look for!)
<img width="745" alt="screen shot 2017-03-04 at 3 39 06 pm" src="https://cloud.githubusercontent.com/assets/1657304/23583150/ca5d8154-00f0-11e7-8543-4bc18d1166b7.png">

It relates to the following issue #s: 
* Fixes #632 