### PR TITLE
Allow tests to run in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk update && apk upgrade && \
     ${BUILD_DEPENDENCIES} \
     ${APP_DEPENDENCIES} && \
     gem install bundler --no-ri --no-rdoc && \
-    cd ${DCAF_DIR} ; bundle install --without development test && \
+    cd ${DCAF_DIR} ; bundle install --without development && \
     apk del ${BUILD_DEPENDENCIES} 
 
 # symlink which nodejs to node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,20 @@
-web:
-  image: colinxfleming/dcaf_case_management
-  command: rails s -p 3000 -b 0.0.0.0
-  volumes:
-    - .:/usr/src/app
-  ports:
-    - "3000:3000"
-  links:
-    - db
-  environment:
-    mongohost: db
-  env_file:
-    - web-variables.env
-db:
-  image: mongo
-  ports:
-    - "27017:27017"
+version: '3.0'
+services:
+  web:
+    build: .
+    image: colinxfleming/dcaf_case_management
+    command: rails s -p 3000 -b 0.0.0.0
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3000:3000"
+    links:
+      - db
+    environment:
+      mongohost: db
+    env_file:
+      - web-variables.env
+  db:
+    image: mongo
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
This updates docker-compose source to allow us to rebuild the image
locally, and includes the 'test' gems so that we can run the rake tests.

@colin I don't know enough Docker to have a 'release' build vs 'development' build. I think the old files were designed for releases, but these updates are designed for development?

This pull request makes the following changes:
* Fix docker-compose to allow building the web image, but also support tagging it appropriately
* Update Dockerfile to not exclude test gems

It relates to the following issue #s: 
* Fixes #901 maybe :)
