### PR TITLE
Allow a user to remove their own calls

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -1,6 +1,6 @@
 # Create method for calls, plus triggers for modal behavior
 class CallsController < ApplicationController
-  before_action :find_patient, only: [:create]
+  before_action :find_patient, only: [:create, :destroy]
 
   def create
     @call = @patient.calls.new call_params
@@ -10,8 +10,18 @@ class CallsController < ApplicationController
     elsif @call.save
       respond_to { |format| format.js }
     else
-      flash[:alert] = 'Call failed to save! Please submit the call again.'
-      redirect_to root_path
+      head :bad_request
+    end
+  end
+
+  def destroy
+    call = @patient.calls.find params[:id]
+    if call.created_by != current_user || !call.recent?
+      head :forbidden
+    elsif call.destroy
+      respond_to { |format| format.js }
+    else
+      head :bad_request
     end
   end
 

--- a/app/views/calls/destroy.js.erb
+++ b/app/views/calls/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#call_log").html("<%= escape_javascript(render partial: 'patients/call_log') %>")

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -13,6 +13,7 @@
         <th>Time</th>
         <th>Result</th>
         <th>CM</th>
+        <th>Actions</th>
       </tr>
       <tbody>
         <% @patient.recent_calls.each do |call| %>
@@ -21,6 +22,11 @@
             <td><%= call.created_at.display_time %></td>
             <td><%= call.status %></td>
             <td><%= call.created_by.name %></td>
+            <td>
+              <% if call.created_by == current_user && call.recent? %>
+                <%= button_to 'Remove', patient_call_path(@patient, call), remote: true, method: :delete, data: { confirm: "Are you sure you want to remove this call from the call log?" }, class: "btn btn-danger" %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
         <% @patient.old_calls.each do |call| %>
@@ -29,6 +35,7 @@
             <td><%= call.created_at.display_time %></td>
             <td><%= call.status %></td>
             <td><%= call.created_by.name %></td>
+            <td></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     post 'search', to: 'dashboards#search', defaults: { format: :js }
     resources :users, only: [:new, :create, :index]
     resources :patients, only: [ :create, :edit, :update ] do
-      resources :calls, only: [ :create ]
+      resources :calls, only: [ :create, :destroy ]
       resources :notes, only: [ :create, :update ]
       resources :external_pledges, only: [ :create, :update, :destroy ]
     end


### PR DESCRIPTION
Add a destroy endpoint to calls controller. 
Add delete button to calls in call log that's created recently by the current user.

![](http://g.recordit.co/oy9psd7t2G.gif)

* Fixes https://github.com/colinxfleming/dcaf_case_management/issues/524

@colinxfleming sending this your way while I write some tests and hopefully find a way to get the tests running locally.