### PR TITLE
Expand Clinic model fields

### DIFF
--- a/app/assets/javascripts/clinics.coffee
+++ b/app/assets/javascripts/clinics.coffee
@@ -1,3 +1,11 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+ready = ->
+  $(document).on 'show.bs.collapse', '.collapsible-clinic-details', (event) ->
+    $(event.target).siblings('.clinic-detail-toggle').text('Fewer Details')
+
+  $(document).on 'hide.bs.collapse', '.collapsible-clinic-details', (event) ->
+    $(event.target).siblings('.clinic-detail-toggle').text('More Details')
+
+$(document).on 'ready page:load', ready

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -70,6 +70,13 @@ $font-size: 17px;
   background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
 }
 
+// empty add - char
+.blush:empty:before {
+  content: '\2013';
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
 // add spacing
 .margin-bottom {
   margin-bottom: 100px;

--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -39,7 +39,10 @@ class ClinicsController < ApplicationController
 
   def clinic_params
     params.require(:clinic).permit(
-      :name, :address, :city, :state, :zip
+      :name, :street_address, :city, :state, :zip,
+      :phone, :accepts_naf, :gestational_limit,
+      :costs_9wks, :costs_12wks, :costs_18wks,
+      :costs_24wks, :costs_30wks
     )
   end
 end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -9,14 +9,23 @@ class Clinic
 
   # Fields
   field :name, type: String
-  field :address, type: String
+  field :street_address, type: String
   field :city, type: String
   field :state, type: String
   field :zip, type: String
+  field :phone, type: String
   field :active, type: Boolean, default: true
+  field :accepts_naf, type: Boolean, default: false
+  field :gestational_limit, type: Integer
+  field :costs_9wks, type: Integer
+  field :costs_12wks, type: Integer
+  field :costs_18wks, type: Integer
+  field :costs_24wks, type: Integer
+  field :costs_30wks, type: Integer
+
 
   # Validations
-  validates :name, :address, :city, :state, :zip, presence: true
+  validates :name, :street_address, :city, :state, :zip, presence: true
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/app/views/clinics/index.html.erb
+++ b/app/views/clinics/index.html.erb
@@ -9,10 +9,46 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <%= clinic.address %>, <%= clinic.city %>, <%= clinic.state %> <%= clinic.zip %>
+      <p><%= clinic.street_address %>, <%= clinic.city %>, <%= clinic.state %> <%= clinic.zip %></p>
+      <p><%= clinic.phone %></p>
     </div>
-    <div class="col-md-6">
-      Other stuff placeholder
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="collapse collapsible-clinic-details" id="<%= clinic.id %>">
+        <div class="additional-clinic-details">
+          <div class="accepts-naf clinic-detail-group">
+            <label>Accepts NAF?</label>
+            <p class="blush"><%= clinic.accepts_naf ? 'Yes' : 'No' %></p>
+          </div>
+          <div class="gestational-limit clinic-detail-group">
+            <label>Gestational Limit</label>
+            <p class="blush"><%= clinic.gestational_limit %></p>
+          </div>
+          <div class="clinic-costs clinic-detail-group">
+            <label>Clinic Costs</label>
+            <table class="clinic-costs-table table">
+              <thead>
+                <th>9 Weeks</th>
+                <th>12 Weeks</th>
+                <th>18 Weeks</th>
+                <th>24 Weeks</th>
+                <th>30 Weeks</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>$<span class="blush"><%= clinic.costs_9wks %></span></td>
+                  <td>$<span class="blush"><%= clinic.costs_12wks %></span></td>
+                  <td>$<span class="blush"><%= clinic.costs_18wks %></span></td>
+                  <td>$<span class="blush"><%= clinic.costs_24wks %></span></td>
+                  <td>$<span class="blush"><%= clinic.costs_30wks %></span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <a role="button" class="clinic-detail-toggle" data-toggle="collapse" href="#<%= clinic.id %>" aria-expanded="false" aria-controls="<%= clinic.id %>">More details</a>
     </div>
   </div>
 <% end %>

--- a/app/views/clinics/new.html.erb
+++ b/app/views/clinics/new.html.erb
@@ -1,10 +1,26 @@
 <h1>Add a new clinic</h1>
 
 <%= bootstrap_form_for @clinic do |f| %>
-  <%= f.text_field :name, autocomplete: 'off' %>
-  <%= f.text_field :address, autocomplete: 'off' %>
-  <%= f.text_field :city, autocomplete: 'off' %>
-  <%= f.text_field :state, autocomplete: 'off' %>
-  <%= f.text_field :zip, autocomplete: 'off' %>
-  <%= f.submit 'Add clinic' %>
+  <div class="col-sm-12">
+    <div class="row">
+      <div class="info-form-left col-sm-6">
+        <%= f.text_field :name, autocomplete: 'off' %>
+        <%= f.text_field :street_address, autocomplete: 'off' %>
+        <%= f.text_field :city, autocomplete: 'off' %>
+        <%= f.text_field :state, autocomplete: 'off' %>
+        <%= f.text_field :zip, autocomplete: 'off' %>
+        <%= f.text_field :phone, autocomplete: 'off', pattern: "[0-9]{10}|[0-9]{3}\.[0-9]{3}\.[0-9]{4}|[0-9]{3}[-][0-9]{3}[-][0-9]{4}" %>
+        <%= f.check_box :accepts_naf, autocomplete: 'off' %>
+      </div>
+      <div class="info-form-right col-sm-6">
+        <%= f.number_field :gestational_limit, autocomplete: 'off' %>
+        <%= f.number_field :costs_9wks, autocomplete: 'off' %>
+        <%= f.number_field :costs_12wks, autocomplete: 'off' %>
+        <%= f.number_field :costs_18wks, autocomplete: 'off' %>
+        <%= f.number_field :costs_24wks, autocomplete: 'off' %>
+        <%= f.number_field :costs_30wks, autocomplete: 'off' %>
+      </div>
+    </div>
+    <%= f.submit 'Add clinic' %>
+  </div>
 <% end %>


### PR DESCRIPTION
* Expand Clinic model to prepare for integration with Clinic Finder gem
Includes new fields:
- Phone
- Accepts Naf
- Gestation Limit
- Costs 9wks - 30wks

* New fields reflected when adding a new clinic
* Details reflected in the list of clinics
* Added collapsible details to existing clinic list

Add new clinic view updated:
<img width="969" alt="screen shot 2017-03-04 at 6 05 31 pm" src="https://cloud.githubusercontent.com/assets/1657304/23583872/2e0ca194-0105-11e7-87b2-9bddd956621f.png">

Clinic Lists with Details Collapsed:
<img width="1196" alt="screen shot 2017-03-04 at 8 46 38 pm" src="https://cloud.githubusercontent.com/assets/1657304/23584636/b8576026-011b-11e7-956c-4d50a4286edc.png">

Clinic Lists with Details Expanded:
<img width="1192" alt="screen shot 2017-03-04 at 8 46 47 pm" src="https://cloud.githubusercontent.com/assets/1657304/23584637/b9ea27e8-011b-11e7-9e7d-5e551edf1894.png">

It relates to the following issue #s: 
* Fixes #146 
