### PR TITLE
Reorder fields to match form

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -22,15 +22,15 @@
         </div>  
         <div class="info-form-left col-sm-6">
           <%= f.fields_for patient.fulfillment do |pt| %>
-            <%= pt.text_field :procedure_date,
-                                  label: 'Procedure date',
-                                  autocomplete: 'off', format: '%Y-%m-%d',
-                                  placeholder: 'YYYY-MM-DD' %>
+            <%= pt.text_field :procedure_cost, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
             <%= pt.select :gestation_at_procedure, 
                           options_for_select(weeks_options, patient.fulfillment.gestation_at_procedure),
                           label: 'Weeks along at procedure',
                           autocomplete: 'off' %>
-            <%= pt.text_field :procedure_cost, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
+            <%= pt.text_field :procedure_date,
+                                  label: 'Procedure date',
+                                  autocomplete: 'off', format: '%Y-%m-%d',
+                                  placeholder: 'YYYY-MM-DD' %>
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">


### PR DESCRIPTION
The fulfillment form has fields in a certain order that weren't matched
on the web site. This updates the web site to match the fulfillment form
order.

Fixes issue #907.

This pull request makes the following changes:
* Reorder fields as I understand they should be

![screenshot from 2017-03-04 19-09-22](https://cloud.githubusercontent.com/assets/361428/23584182/678d40f0-010e-11e7-86b2-eb3b27e4736b.png)
