### PR TITLE
Improve cancel pledge flow

### DIFF
--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -59,7 +59,7 @@ $font-size: 17px;
       
     }
   }
-  a.submit-btn {
+  a.submit-btn, a.cancel-btn {
     font-size: 22px;
   }
 
@@ -81,19 +81,11 @@ $font-size: 17px;
   }
 }
 
-#submit-pledge-button {
+#submit-pledge-button, #cancel-pledge-button {
   font-size: 22px;
   font-weight: bold;
 }
 
-a.submit-pledge-button {
+a.submit-pledge-button, a.cancel-pledge-button {
   text-decoration: none;
 }
-
-
-
-
-
-
-
-

--- a/app/helpers/pledges_helper.rb
+++ b/app/helpers/pledges_helper.rb
@@ -6,4 +6,12 @@ module PledgesHelper
       'Submit pledge'
     end
   end
+
+  def cancel_pledge_button
+    content_tag :span, class: 'btn btn-warning btn-lg cancel-btn btn-block',
+                       aria: { hidden: true },
+                       id: 'cancel-pledge-button' do
+      'Cancel pledge'
+    end
+  end
 end

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -12,7 +12,11 @@
   </ul>
   <div class="row">
     <div class="col-sm-10">
-      <%= link_to submit_pledge_button, '#pledge-modal', class: 'submit-pledge-button', data: { toggle: 'modal' } %>
+      <% if not patient.pregnancy.pledge_sent %>
+        <%= link_to submit_pledge_button, '#pledge-modal', class: 'submit-pledge-button', data: { toggle: 'modal' } %>
+      <% else %>
+        <%= link_to cancel_pledge_button, '#pledge-modal', class: 'cancel-pledge-button', data: { toggle: 'modal' } %>
+      <% end %>
     </div>
   </div>
 </section>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -40,7 +40,7 @@
     <div class="col-sm-12">
       <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
         <%= f.fields_for patient.pregnancy do |p| %>
-          <%= p.check_box :pledge_sent, label: 'I sent the pledge' %>
+          <%= p.check_box :pledge_sent, label: 'Uncheck this box to rescind the pledge' %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -1,4 +1,6 @@
 <%= render '/shared/multi_modal', disable_next: disable_continue?(patient), :captured => capture { %>
+
+<% if not patient.pregnancy.pledge_sent %>
   <div class="row hide" data-step="1" data-title="Confirm the following information is correct:">
     <% if patient.pregnancy.pledge_info_present? %>
       <% patient.pregnancy.pledge_info_errors.each do |error| %>
@@ -28,4 +30,21 @@
       <% end %>
     </div>
   </div>
+<% else %>
+  <div class="row hide" data-step="1" data-title="Cancel pledge:">
+    <p class="col-sm-12">If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page.</p>
+  </div>
+
+  <div class="row hide" data-step="2" data-title="Cancel pledge:">
+    <p class="col-sm-12">To confirm you want to cancel this pledge, please uncheck the check box below.</p>
+    <div class="col-sm-12">
+      <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
+        <%= f.fields_for patient.pregnancy do |p| %>
+          <%= p.check_box :pledge_sent, label: 'I sent the pledge' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <% } %>


### PR DESCRIPTION
Previously you could 'cancel' a pledge by re-performing the 'submit
pledge' flow and unchecking the box. This PR updates the button text and
modal dialog text to make it more clear how to perform this process.

Fixes #457.

This pull request makes the following changes:
* Replace 'submit pledge' button with 'cancel pledge' when a pledge has been sent
* When 'cancel pledge' is clicked, show modal that allows cancelling pledge

![screenshot from 2017-03-04 20-01-59](https://cloud.githubusercontent.com/assets/361428/23584409/aea13de6-0115-11e7-93eb-260165a15a33.png)

Modal page 1:

![screenshot from 2017-03-04 20-04-02](https://cloud.githubusercontent.com/assets/361428/23584413/c8746e96-0115-11e7-8c27-a7321b5b27d0.png)

Modal page 2:

![screenshot from 2017-03-04 20-06-14](https://cloud.githubusercontent.com/assets/361428/23584419/1073e5aa-0116-11e7-9762-58cc424d4d4d.png)
