### PR TITLE
Fix Clinic db seeds following 73339ad6

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -143,9 +143,9 @@ patient_in_completed_calls.calls.create! status: 'Left voicemail',
                                         created_by: user
 
 # Seed a pair of clinics, Sample 1 and Sample 2
-Clinic.create! name: 'Sample Clinic 1 - DC', address: '123 Fake Street',
+Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '123 Fake Street',
                city: 'Washington', state: 'DC', zip: '20011'
-Clinic.create! name: 'Sample Clinic 2 - VA', address: '123 Fake Street',
+Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '123 Fake Street',
                city: 'Arlington', state: 'DC', zip: '22204'
                       
 # Log results

--- a/test/controllers/clinics_controller_test.rb
+++ b/test/controllers/clinics_controller_test.rb
@@ -38,7 +38,7 @@ class ClinicsControllerTest < ActionController::TestCase
     end
 
     it 'should fail if fields not there' do
-      @new_clinic[:address] = ''
+      @new_clinic[:street_address] = ''
       assert_no_difference 'Clinic.count' do
         post :create, clinic: @new_clinic
       end

--- a/test/factories/clinic.rb
+++ b/test/factories/clinic.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :clinic do
     name 'Friendly Clinic'
-    address '123 Fake Street'
+    street_address '123 Fake Street'
     city 'Washington'
     state 'DC'
     zip '20011'

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -11,7 +11,7 @@ class ClinicTest < ActiveSupport::TestCase
       assert @clinic.valid?
     end
 
-    [:name, :address, :city, :state, :zip].each do |attr|
+    [:name, :street_address, :city, :state, :zip].each do |attr|
       it "requires a #{attr}" do
         @clinic[attr] = nil
         refute @clinic.valid?


### PR DESCRIPTION
It looks like `Clinic#address` is `Clinic#street_address` as of 73339ad6, so this updates the database seeds to match.