### PR TITLE
Reset session before each integration test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,8 @@ class ActionDispatch::IntegrationTest
   include OmniauthMocker
   OmniAuth.config.test_mode = true
 
+  before { Capybara.reset_sessions! }
+
   def log_in_as(user, line = 'DC')
     log_in user
     select_line line


### PR DESCRIPTION
Resetting Capybara sessions before every integration test fixes this flakey failure for me:

```
Capybara::ElementNotFound:         Capybara::ElementNotFound: Unable to find field "Email"
            test/test_helper.rb:50:in `log_in'
            test/test_helper.rb:44:in `log_in_as'
            test/integration/pledge_fulfillment_test.rb:22:in `block (2 levels) in <class:PledgeFulfillmentTest>'
```