### PR TITLE
Add tooltip support next to form field labels

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -44,4 +44,14 @@ ready = ->
   if $("#patient_pregnancy_procedure_cost").val()
     updateBalance()
 
+  # put a help icon next to form field labels that have the "tooltip-header" class
+  # the text that shows up in the tooltip is from the label's corresponding form field's "data-tooltip-text" attribute
+  $( '.tooltip-header' ).append( ' <span class="tooltip-header-help">(?)</span>' )
+  $( '.tooltip-header' ).parent( '.form-group' ).find( '.form-control' ).each ->
+    $(@).parents( '.form-group' ).find( '.tooltip-header-help' ).tooltip( {
+      html: true,
+      placement: 'top',
+      title: $(@).data( 'tooltip-text' )
+    } )
+
 $(document).on 'ready page:load', ready

--- a/app/assets/stylesheets/patients.scss
+++ b/app/assets/stylesheets/patients.scss
@@ -1,3 +1,9 @@
 // Place all the styles related to the Patients controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.tooltip-header-help {
+    color: #737373;
+    border-bottom: 1px dotted #737373;
+    cursor: pointer;
+}

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -63,4 +63,12 @@ module PatientsHelper
   def disable_continue?(patient)
     patient.pregnancy.pledge_info_present? ? 'disabled="disabled"' : ''
   end
+
+  def dcaf_pledge_limit_help_text
+    first_tri = ENV['DCAF_PLEDGE_LIMIT_FIRST_TRI'] || 100;
+    second_tri = ENV['DCAF_PLEDGE_LIMIT_SECOND_TRI'] || 300;
+    later_care = ENV['DCAF_PLEDGE_LIMIT_LATER_CARE'] || 600;
+
+    "Pledge Limit Guidelines:<br />1st trimester (7-12 weeks): $#{first_tri}<br />2nd trimester (12-24 weeks): $#{second_tri}<br />Later care (25+ weeks): $#{later_care}"
+  end
 end

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -58,7 +58,7 @@
               <%= f.fields_for patient.pregnancy do |pt| %>
                 <%= pt.number_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
                 <%= pt.number_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
-                <%= pt.number_field :dcaf_soft_pledge, label: 'DCAF pledge', autocomplete: 'off', prepend: '$' %>
+                <%= pt.number_field :dcaf_soft_pledge, label: 'DCAF pledge', autocomplete: 'off', prepend: '$', label_class: 'tooltip-header', data: { 'tooltip-text': dcaf_pledge_limit_help_text() } %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

* Added support for tooltip help thingys next to form field labels
* Added a tooltip next to the DCAF Pledge field that shows recommended pledge limits

<img width="164" alt="screen shot 2017-03-05 at 2 30 04 pm" src="https://cloud.githubusercontent.com/assets/7842799/23592076/4efdf226-01b0-11e7-9d9f-07d04d552192.png">

<img width="278" alt="screen shot 2017-03-05 at 2 29 12 pm" src="https://cloud.githubusercontent.com/assets/7842799/23592079/592033e0-01b0-11e7-9b8a-742c41803ba5.png">

It relates to the following issue #s: 
* Fixes #793 