### PR TITLE
Add instructions for making a first contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [A deployed demo version of what's in the master branch is at: https://sandbox.dcabortionfund.org/](https://sandbox.dcabortionfund.org/)
 
 
-## Next major project milestone: April 1: Launch to Baltimore!
+## Next major project milestone: June 15: Launch to Baltimore!
 
 ## [Come hang out with us on slack!](https://codefordc.slack.com/messages/dcaf_case_management)
 
@@ -22,6 +22,8 @@ The three co-leads on this project are @colinxfleming (rails and technical lead)
 
 
 ## Contributing to this Project
+
+### [If this is your first time, a good way to get oriented is to leave our users a nice note! Check out instructions here.](docs/YOUR_FIRST_CONTRIBUTION.md)
 
 ### tl;dr
 * We run on forks and pull requests

--- a/docs/YOUR_FIRST_CONTRIBUTION.md
+++ b/docs/YOUR_FIRST_CONTRIBUTION.md
@@ -1,0 +1,11 @@
+# Making your first contribution
+
+If you're new to the project, a great first contribution is to [add a nice message for our case managers](https://github.com/colinxfleming/dcaf_case_management/issues/884). Our case managers see these messages on login, so it's a great opportunity to show some appreciation for the hard work they're doing.
+
+To do so, follow the following instructions:
+
+* Set up the app per instructions in [SETUP.md](docs/setup.md)
+* Open up `app/helpers/welcome_message_helper.rb`
+* Add a nice message to the end of the array in `welcome_messages`
+* Commit your change
+* Pull request your change, and @colinxfleming will merge it in!

--- a/docs/YOUR_FIRST_CONTRIBUTION.md
+++ b/docs/YOUR_FIRST_CONTRIBUTION.md
@@ -4,8 +4,8 @@ If you're new to the project, a great first contribution is to [add a nice messa
 
 To do so, follow the following instructions:
 
-* Set up the app per instructions in [SETUP.md](docs/setup.md)
+* Set up the app per instructions in [SETUP.md](setup.md)
 * Open up `app/helpers/welcome_message_helper.rb`
 * Add a nice message to the end of the array in `welcome_messages`
 * Commit your change
-* Pull request your change, and @colinxfleming will merge it in!
+* Pull request your change, referencing issue #884 in the description of your changes


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I feel like we've gotten a lot of benefits out of asking people to leave our CMs nice notes per #884, so this PR makes a few changes to flag it as a part of the getting started process. 

This pull request makes the following changes:
* Suggests that new people's first contributions be making a PR against #884 
* Updates the Baltimore rollout date to June

It relates to the following issue #s: 
* Fixes #946 
