### PR TITLE
Fix modals with Turbolinks UPGRAYEDD

### DIFF
--- a/app/assets/javascripts/external_pledges.coffee
+++ b/app/assets/javascripts/external_pledges.coffee
@@ -4,6 +4,6 @@
 
 jQuery ->
   # use event that works with rails turbolinks
-  $(document).on 'ready page:load', ->
+  $(document).on 'ready turbolinks:load', ->
     # select all elements with id ending with "modal"
     $('[id$=modal]').modalSteps()


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fixes issue with modals not loading on initial page load, follows top answer from: https://stackoverflow.com/questions/17317816/rails-javascript-only-works-after-reload

Of note, there are other spots in the code base where it seems this could be applied, this PR for now only updates the pledges modal

This pull request makes the following changes:
* Change to the event that the modals use from page:load to the new turbolinks:load

It relates to the following issue #s: 
* Fixes #968 
