### PR TITLE
Enforce uniqueness on Clinic#name

### DIFF
--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -14,6 +14,7 @@ class Clinic
   field :state, type: String
   field :zip, type: String
   field :phone, type: String
+  field :fax, type: String
   field :active, type: Boolean, default: true
   field :accepts_naf, type: Boolean, default: false
   field :gestational_limit, type: Integer
@@ -22,6 +23,7 @@ class Clinic
 
   # Validations
   validates :name, :street_address, :city, :state, :zip, presence: true
+  validates :name, uniqueness: true
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/app/views/clinics/_clinic_form.html
+++ b/app/views/clinics/_clinic_form.html
@@ -8,6 +8,7 @@
         <%= f.text_field :state, autocomplete: 'off' %>
         <%= f.text_field :zip, autocomplete: 'off' %>
         <%= f.text_field :phone, autocomplete: 'off', pattern: "[0-9]{10}|[0-9]{3}\.[0-9]{3}\.[0-9]{4}|[0-9]{3}[-][0-9]{3}[-][0-9]{4}" %>
+        <%= f.text_field :fax, autocomplete: 'off', pattern: "[0-9]{10}|[0-9]{3}\.[0-9]{3}\.[0-9]{4}|[0-9]{3}[-][0-9]{3}[-][0-9]{4}" %>
         <%= f.check_box :accepts_naf, autocomplete: 'off' %>
       </div>
       <div class="info-form-right col-sm-6">

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -17,6 +17,12 @@ class ClinicTest < ActiveSupport::TestCase
         refute @clinic.valid?
       end
     end
+
+    it 'should be unique on name' do
+      clinic_name = @clinic.name
+      dupe_clinic = create :clinic, name: clinic_name, created_by: @user
+      refute dupe_clinic.valid?
+    end
   end
 
   describe 'mongoid attachments' do

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -20,7 +20,7 @@ class ClinicTest < ActiveSupport::TestCase
 
     it 'should be unique on name' do
       clinic_name = @clinic.name
-      dupe_clinic = create :clinic, name: clinic_name, created_by: @user
+      dupe_clinic = build :clinic, name: clinic_name, created_by: @user
       refute dupe_clinic.valid?
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Hotfixes an issue that was allowing duplicate clinics. Also adds fax number.

This pull request makes the following changes:
* Require uniqueness on name for clinics
* Add fax

No issue #