### PR TITLE
turbolinks is the devil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'turbolinks'
+gem 'turbolinks', '2.5.3'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bootstrap-sass', '~> 3.3', '>= 3.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,9 +383,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.6)
     timecop (0.8.1)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
+    turbolinks (2.5.3)
+      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.1)
@@ -472,7 +471,7 @@ DEPENDENCIES
   simplecov
   spring
   timecop
-  turbolinks
+  turbolinks (= 2.5.3)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turbolinks is the devil.

This pull request makes the following changes:
* Reverts turbolinks to 2.5.3 to get all our js to work again

It relates to the following issue #s: 
* Fixes #968 
