### PR TITLE
Move clinics away from env vars to model

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -26,7 +26,6 @@ class PatientsController < ApplicationController
   end
 
   def update
-    puts params
     if @patient.update_attributes patient_params
       head :ok
     else

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -26,6 +26,7 @@ class PatientsController < ApplicationController
   end
 
   def update
+    puts params
     if @patient.update_attributes patient_params
       head :ok
     else
@@ -69,13 +70,12 @@ class PatientsController < ApplicationController
       :name, :primary_phone, :other_contact, :other_phone,
       :other_contact_relationship, :line, :voicemail_preference, :spanish,
       # fields in dashboard
-      :clinic_name,
+      # :clinic_name,
       :appointment_date,
       :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income,
       :household_size_adults, :household_size_children, :insurance,
       :referred_by, :initial_call_date, :urgent_flag,
-      clinic: [:id, :name, :street_address_1, :street_address_2,
-               :city, :state, :zip],
+      :clinic,
       pregnancy: [:last_menstrual_period_days, :last_menstrual_period_weeks,
                   :resolved_without_dcaf, :referred_to_clinic, :procedure_cost,
                   :pledge_sent, :patient_contribution, :naf_pledge, :dcaf_soft_pledge],

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -75,7 +75,7 @@ class PatientsController < ApplicationController
       :age, :race_ethnicity, :city, :state, :zip, :employment_status, :income,
       :household_size_adults, :household_size_children, :insurance,
       :referred_by, :initial_call_date, :urgent_flag,
-      :clinic,
+      :clinic_id,
       pregnancy: [:last_menstrual_period_days, :last_menstrual_period_weeks,
                   :resolved_without_dcaf, :referred_to_clinic, :procedure_cost,
                   :pledge_sent, :patient_contribution, :naf_pledge, :dcaf_soft_pledge],

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -58,8 +58,6 @@ module PatientsHelper
   def clinic_options
     Clinic.where(active: true).map { |clinic| [clinic.name, clinic.id] }
       .unshift nil
-    # (ENV['CLINICS'].try(:split, ',') || ['Sample Clinic 1', 'Sample Clinic 2'])
-      # .unshift nil
   end
 
   def disable_continue?(patient)

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -56,8 +56,10 @@ module PatientsHelper
   end
 
   def clinic_options
-    (ENV['CLINICS'].try(:split, ',') || ['Sample Clinic 1', 'Sample Clinic 2'])
+    Clinic.where(active: true).map { |clinic| [clinic.name, clinic.id] }
       .unshift nil
+    # (ENV['CLINICS'].try(:split, ',') || ['Sample Clinic 1', 'Sample Clinic 2'])
+      # .unshift nil
   end
 
   def disable_continue?(patient)

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -8,7 +8,7 @@ class Clinic
   include ClinicsHelper
 
   # Relationships
-  belongs_to :patient
+  has_many :patients
 
   # Fields
   field :name, type: String

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -7,6 +7,9 @@ class Clinic
   include Mongoid::Userstamp
   include ClinicsHelper
 
+  # Relationships
+  belongs_to :patient
+
   # Fields
   field :name, type: String
   field :street_address, type: String

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -16,7 +16,7 @@ class Patient
 
   # Relationships
   has_and_belongs_to_many :users, inverse_of: :patients
-  has_one :clinic
+  belongs_to :clinic
   embeds_one :pregnancy
   embeds_one :fulfillment
   embeds_many :calls
@@ -26,7 +26,7 @@ class Patient
   # Enable mass posting in forms
   accepts_nested_attributes_for :pregnancy
   accepts_nested_attributes_for :fulfillment
-  accepts_nested_attributes_for :clinic
+  # accepts_nested_attributes_for :clinic
 
   # Fields
   field :name, type: String # strip
@@ -34,7 +34,7 @@ class Patient
   field :other_contact, type: String
   field :other_phone, type: String
   field :other_contact_relationship, type: String
-  field :clinic_name, type: String
+  # field :clinic_name, type: String
   field :identifier, type: String
 
   enum :voicemail_preference, [:not_specified, :no, :yes]

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -26,7 +26,6 @@ class Patient
   # Enable mass posting in forms
   accepts_nested_attributes_for :pregnancy
   accepts_nested_attributes_for :fulfillment
-  # accepts_nested_attributes_for :clinic
 
   # Fields
   field :name, type: String # strip
@@ -34,7 +33,6 @@ class Patient
   field :other_contact, type: String
   field :other_phone, type: String
   field :other_contact_relationship, type: String
-  # field :clinic_name, type: String
   field :identifier, type: String
 
   enum :voicemail_preference, [:not_specified, :no, :yes]

--- a/app/models/pregnancy.rb
+++ b/app/models/pregnancy.rb
@@ -71,7 +71,7 @@ class Pregnancy
   def pledge_info_presence
     errors.add(:pledge_sent, 'DCAF soft pledge field cannot be blank') if dcaf_soft_pledge.blank?
     errors.add(:pledge_sent, 'Patient name cannot be blank') if patient.name.blank?
-    errors.add(:pledge_sent, 'Clinic name cannot be blank') if patient.clinic_name.blank?
+    errors.add(:pledge_sent, 'Clinic name cannot be blank') if patient.clinic.blank?
     errors.add(:pledge_sent, 'Appointment date cannot be blank') if patient.appointment_date.blank?
   end
 end

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -12,7 +12,7 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
-              <%= f.collection_select :clinic, Clinic.all.unshift(OpenStruct.new(name: nil, value: nil)), :id, :name %>
+              <%= f.select :clinic, options_for_select(clinic_options, patient.clinic) %>
             </div>
           </div>
 

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -12,7 +12,7 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
-              <%= f.select :clinic, options_for_select(clinic_options, patient.clinic.id) %>
+              <%= f.select :clinic_id, options_for_select(clinic_options, patient.clinic.try(:id)) %>
             </div>
           </div>
 

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -12,7 +12,7 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
-              <%= f.select :clinic_name, options_for_select(clinic_options, patient.clinic_name) %>
+              <%= f.collection_select :clinic, Clinic.all.unshift(OpenStruct.new(name: nil, value: nil)), :id, :name %>
             </div>
           </div>
 

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -12,7 +12,7 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
-              <%= f.select :clinic, options_for_select(clinic_options, patient.clinic) %>
+              <%= f.select :clinic, options_for_select(clinic_options, patient.clinic.id) %>
             </div>
           </div>
 

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -7,7 +7,7 @@
           <h2>Pledge Fulfillment</h2>
           <p>Please confirm that the clinic and pledge amounts are correct:</p>
           <ul>
-            <li>Clinic: <%= @patient.clinic_name %></li>
+            <li>Clinic: <%= @patient.clinic.try(:name) %></li>
             <li>DCAF Pledge Amount: $<%= @patient.pregnancy.dcaf_soft_pledge %></li>
           </ul>
         </div>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -40,7 +40,7 @@
 
   <%= f.text_field :age, autocomplete: 'off' %>
   <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), label: 'Race / Ethnicity', autocomplete: 'off' %>
-  <%= f.select :clinic_name, options_for_select(clinic_options) %>
+  <%= f.select :clinic_id, options_for_select(clinic_options) %>
 
   <%= f.text_field :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD' %>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ user3 = User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
 Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '123 Fake Street',
                city: 'Washington', state: 'DC', zip: '20011'
 Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '123 Fake Street',
-               city: 'Arlington', state: 'DC', zip: '22204'
+               city: 'Arlington', state: 'VA', zip: '22204'
 
 # Create ten patients
 10.times do |i|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,12 @@ user2 = User.create! name: 'testuser2', email: 'test2@test.com',
 user3 = User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
                     password: 'P4ssword', password_confirmation: 'P4ssword'
 
+# Seed a pair of clinics, Sample 1 and Sample 2
+Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '123 Fake Street',
+               city: 'Washington', state: 'DC', zip: '20011'
+Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '123 Fake Street',
+               city: 'Arlington', state: 'DC', zip: '22204'
+
 # Create ten patients
 10.times do |i|
   flag = i.even? ? true : false
@@ -80,13 +86,13 @@ Patient.all.each do |patient|
   # Add example of patient with appointment one week from today && clinic selected
   if patient.name == 'Patient 2'
     patient.update! name: "Clinic and Appt - 2",
-                    clinic_name: "Sample Clinic 1",
+                    clinic: Clinic.first,
                     appointment_date: (1.week.from_now)
   end
 
   # Add example of patient with a pledge submitted
   if patient.name == 'Patient 3'
-    patient.update! clinic_name: "Sample Clinic 1",
+    patient.update! clinic: Clinic.first,
                     appointment_date: 10.days.from_now
     patient.pregnancy.update! naf_pledge: 2000,
                              procedure_cost: 4000,
@@ -142,12 +148,6 @@ user.add_patient patient_in_completed_calls
 patient_in_completed_calls.calls.create! status: 'Left voicemail',
                                         created_by: user
 
-# Seed a pair of clinics, Sample 1 and Sample 2
-Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '123 Fake Street',
-               city: 'Washington', state: 'DC', zip: '20011'
-Clinic.create! name: 'Sample Clinic 2 - VA', street_address: '123 Fake Street',
-               city: 'Arlington', state: 'DC', zip: '22204'
-                      
 # Log results
 puts "Seed completed! Inserted #{Patient.count} patient objects. \n" \
      "User created! Credentials are as follows: " \

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -9,6 +9,7 @@ class PatientsControllerTest < ActionController::TestCase
                       primary_phone: '123-456-7890',
                       other_phone: '333-444-5555'
     @pregnancy = create :pregnancy, patient: @patient
+    @clinic = create :clinic
   end
 
   describe 'create method' do
@@ -71,7 +72,7 @@ class PatientsControllerTest < ActionController::TestCase
     it 'should contain the current record' do
       assert_match /Susie Everyteen/, response.body
       assert_match /123-456-7890/, response.body
-      assert_match /Sample Clinic 1/, response.body
+      assert_match /Friendly Clinic/, response.body
     end
   end
 

--- a/test/factories/clinic.rb
+++ b/test/factories/clinic.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :clinic do
-    name 'Friendly Clinic'
+    sequence :name do |n| 
+      "Friendly Clinic #{n}"
+    end
     street_address '123 Fake Street'
     city 'Washington'
     state 'DC'

--- a/test/integration/data_entry_test.rb
+++ b/test/integration/data_entry_test.rb
@@ -4,6 +4,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user
+    @clinic = create :clinic
     log_in_as @user
     visit data_entry_path
     has_text? 'PATIENT ENTRY' # wait until load
@@ -28,7 +29,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
       fill_in 'Dcaf soft pledge', with: '100'
       fill_in 'Age', with: '30'
       select 'Other', from: 'patient_race_ethnicity'
-      select 'Sample Clinic 1', from: 'patient_clinic_name'
+      select @clinic.name, from: 'patient_clinic_id'
       fill_in 'Appointment date', with: 1.day.ago.strftime('%Y-%m-%d')
       select 'DC Medicaid', from: 'patient_insurance'
       select '1', from: 'patient_household_size_adults'
@@ -84,7 +85,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
     it 'should log a new patient ready for further editing: abortion' do
       click_link 'Abortion Information'
       within :css, '#abortion_information' do
-        assert_equal 'Sample Clinic 1', find('#patient_clinic_name').value
+        assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
         assert has_field? 'Abortion cost', with: '200'
         assert has_field? 'Patient contribution', with: '150'
         assert has_field? 'National Abortion Federation pledge', with: '50'

--- a/test/integration/display_pledge_info_errors_test.rb
+++ b/test/integration/display_pledge_info_errors_test.rb
@@ -6,6 +6,7 @@ class DisplayPledgeInfoErrorsTest < ActionDispatch::IntegrationTest
     @user = create :user
     @patient = create :patient
     @pregnancy = create :pregnancy, patient: @patient
+    @clinic = create :clinic
     log_in_as @user
     visit edit_patient_path @patient
     has_text? 'First and last name' # wait until page loads
@@ -22,7 +23,7 @@ class DisplayPledgeInfoErrorsTest < ActionDispatch::IntegrationTest
     end
 
     it 'should not show errors when information is present' do
-      @patient = create :patient, clinic_name: 'Nice Clinic',
+      @patient = create :patient, clinic: @clinic,
                                   appointment_date: 14.days.from_now
       @pregnancy = create :pregnancy, patient: @patient, dcaf_soft_pledge: 500
       visit edit_patient_path @patient

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -18,6 +18,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
   describe 'submitting a pledge' do
     it 'should let you mark a pledge submitted' do
       find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
       wait_for_no_element 'Confirm the following information is correct'

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -4,7 +4,8 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user
-    @patient = create :patient, clinic_name: 'Nice Clinic',
+    @clinic = create :clinic
+    @patient = create :patient, clinic: @clinic,
                                 appointment_date: Time.zone.now + 14
     @pregnancy = create :pregnancy, patient: @patient, dcaf_soft_pledge: 500
     log_in_as @user

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -28,6 +28,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
 
       assert has_text? 'Awesome, you generated a DCAF'
       check 'I sent the pledge'
+      wait_for_ajax
       find('#pledge-next').click
       wait_for_no_element 'Awesome, you generated a DCAF'
 

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -4,6 +4,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user
+    @clinic = create :clinic
     @patient = create :patient
     @pregnancy = create :pregnancy, patient: @patient
     @ext_pledge = create :external_pledge,
@@ -15,9 +16,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     page.driver.resize(2000, 2000)
   end
 
-  after do
-    Capybara.use_default_driver
-  end
+  after { Capybara.use_default_driver }
 
   describe 'changing patient dashboard information' do
     before do
@@ -52,7 +51,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   describe 'changing abortion information' do
     before do
       click_link 'Abortion Information'
-      select 'Sample Clinic 1', from: 'patient_clinic_name'
+      select @clinic.name, from: 'patient_clinic_id'
       check 'Resolved without assistance from DCAF'
       check 'Referred to clinic'
 
@@ -71,7 +70,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
     it 'should alter the information' do
       within :css, '#abortion_information' do
-        assert_equal 'Sample Clinic 1', find('#patient_clinic_name').value
+        assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
         assert has_checked_field?('Resolved without assistance from DCAF')
         # assert has_checked_field?('Referred to clinic') # wonky test for no reason
         # TODO: review after getting clinic logic in place
@@ -167,8 +166,9 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
   describe 'changing fulfillment information' do
     before do
       @user.update role: :admin
+      @clinic = create :clinic
       @patient = create :patient, appointment_date: 2.days.from_now,
-                                  clinic_name: 'Sample Clinic 1'
+                                  clinic: @clinic
       create :pregnancy, patient: @patient,
                          dcaf_soft_pledge: 100,
                          pledge_sent: true

--- a/test/lib/reporting/patient_test.rb
+++ b/test/lib/reporting/patient_test.rb
@@ -45,7 +45,7 @@ class ReportingPatientTest < ActiveSupport::TestCase
         other_contact: 'Yolo'
       )
 
-        # calls this year
+      # calls this year
       (1..5).each do |call_number|
         Timecop.freeze(Time.now - call_number.months - call_number.days) do
           create(
@@ -106,12 +106,13 @@ class ReportingPatientTest < ActiveSupport::TestCase
 
   describe '.pledges_sent_for_line' do
     before do
+      @clinic = create :clinic
       patient = create(
         :patient,
         line: 'VA',
         other_phone: '111-222-3333',
         other_contact: 'Yolo',
-        clinic_name: 'My special clinic',
+        clinic: @clinic,
         appointment_date: Date.today
       )
 
@@ -131,7 +132,7 @@ class ReportingPatientTest < ActiveSupport::TestCase
         line: 'VA',
         other_phone: '111-222-3333',
         other_contact: 'Yolo',
-        clinic_name: 'My special clinic',
+        clinic: @clinic,
         appointment_date: Date.today
       )
 

--- a/test/models/pregnancy_test.rb
+++ b/test/models/pregnancy_test.rb
@@ -45,8 +45,9 @@ class PregnancyTest < ActiveSupport::TestCase
   end
 
   before do
+    @clinic = create :clinic
     @pregnancy.dcaf_soft_pledge = 500
-    @pt_1.clinic_name = 'Nice Clinic'
+    @pt_1.clinic = @clinic
     @pt_1.appointment_date = DateTime.now + 14
   end
 
@@ -64,7 +65,7 @@ class PregnancyTest < ActiveSupport::TestCase
     end
 
     it 'should not validate pledge_sent if the clinic name is blank' do
-      @pt_1.clinic_name = nil
+      @pt_1.clinic = nil
       @pregnancy.pledge_sent = true
       refute @pregnancy.valid?
       assert_equal ['Clinic name cannot be blank'], @pregnancy.errors.messages[:pledge_sent]
@@ -79,7 +80,7 @@ class PregnancyTest < ActiveSupport::TestCase
 
     it 'should produce three error messages if three required fields are blank' do
       @pregnancy.dcaf_soft_pledge = nil
-      @pt_1.clinic_name = nil
+      @pt_1.clinic = nil
       @pt_1.appointment_date = nil
       @pregnancy.pledge_sent = true
       refute @pregnancy.valid?


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This takes remaining steps to move us away from clinics as defined by environment variables into clinics as defined by a model.

Turns out there are a lot of moving parts in those env vars.

<strike>TODO: null out clinic, fix tests</strike> (donezo!)

This pull request makes the following changes:
* Depreciates patient#clinic_name
* bumps seedfile
* establishes `clinic has_many patients` / `patient belongs_to clinic` relations
* adjusts a ton of stuff in support of that

No view changes, I hope!

It relates to the following issue #s: 
* Fixes #973 

(s/o to past us for writing good tests) 