### PR TITLE
Remove link styling on non-link navbar item

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -26,6 +26,14 @@ $font-size: 17px;
       color: #000080;
     }
   }
+
+  .navbar-text{
+    color: $dcaf-color;
+    padding:15px;
+    margin:0px;
+    line-height:20px;
+  }
+
 }
 
 

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -1,6 +1,6 @@
 <% if session[:line] %>
   <ul class="nav navbar-nav navbar-left">
-    <li><%= link_to current_line_display, '#' %></li>
+    <li class="navbar-text"><%= current_line_display %></li>
     <% if ENV['CM_RESOURCES_URL'] %>
       <li><%= link_to 'CM Resources', ENV['CM_RESOURCES_URL'], target: '_blank' %></li>
     <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Changed the styling on the navbar navigation "Your line:" item to reflect that it is not a link.

This pull request makes the following changes:
* Change navbar list item in app/views/layouts/_navigation_links.html.erb from a blank link to static text
* Change navbar list item class in _navigation_links to navbar-text to reflect the previous change
* Change app/assets/stylesheets/application.css.scss. Change .navbar-inverse .navbar-text style to fit existing navbar item styling.

Before:
![before](https://cloud.githubusercontent.com/assets/22413614/24688511/680dcb10-198e-11e7-9714-27db549a9b38.png)

After:
![after](https://cloud.githubusercontent.com/assets/22413614/24688514/6e602968-198e-11e7-8abd-10f8b6dac95b.png)

It relates to the following issue #s: 
* Fixes "Your current line: DC" shouldn't be a link. Fixes #980 
