### PR TITLE
Highlight Project Press Coverage

### DIFF
--- a/docs/PRESS.md
+++ b/docs/PRESS.md
@@ -1,0 +1,9 @@
+# DCAF Case Manager Press Coverage
+
+Following our project's participation in an Abortion Access Hackathon in early 2017, the project was featured in several publications.
+
+2017-04-05 [Coding for Abortion Access](http://www.newyorker.com/tech/elements/coding-for-abortion-access) in the New Yorker.
+
+2017-03-07 [Those at Abortion Access Hackathon Seek to Solve ‘the Very Problems We Are Experiencing’](https://rewire.news/article/2017/03/07/abortion-access-hackathon-seek-solve-problems-experiencing/) at Rewire
+
+2017-03-06 [Techies team up for abortion access hackathon](http://money.cnn.com/2017/03/06/technology/abortion-access-hackathon-san-francisco/) at CNN Tech


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Started a doc to track positive coverage of our project in the press!

This pull request makes the following changes:
* created `docs/PRESS.md` with entries for the coverage following the hackathon

No issue. 