### PR TITLE
unparallelize, remove controller testing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :test do
   gem 'timecop'
   gem 'capybara-screenshot'
   gem 'minitest-ci'
-  gem 'rails-controller-testing'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,10 +319,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.2)
       sprockets-rails (>= 2.0.0)
-    rails-controller-testing (1.0.1)
-      actionpack (~> 5.x)
-      actionview (~> 5.x)
-      activesupport (~> 5.x)
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
@@ -482,7 +478,6 @@ DEPENDENCIES
   rack-attack (~> 5.0.1)
   rack-test (~> 0.6.3)
   rails (>= 5.0.0, < 5.1)
-  rails-controller-testing
   rails_12factor
   rubocop
   ruby_audit

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
   override:
     # Currently rails test is blowing up on CI, so back to rake test for now
     - bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS":
-        parallel: true
+        # parallel: true
         files:
           - test/**/*_test.rb
   post:

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -45,10 +45,6 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       @note.reload
     end
 
-    it 'should render the correct template' do
-      assert_template 'notes/update'
-    end
-
     it 'should respond with success' do
       assert_response :success
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Remove parallelization until we get that sorted out in #992 , remove `rails-controller-testing` gem

It relates to the following issue #s: 
* Fixes #991 
