### PR TITLE
Move patient methods to concerns

### DIFF
--- a/app/models/concerns/attribute_displayable.rb
+++ b/app/models/concerns/attribute_displayable.rb
@@ -1,0 +1,13 @@
+module AttributeDisplayable
+  extend ActiveSupport::Concern
+
+  def primary_phone_display
+    return nil unless primary_phone.present?
+    "#{primary_phone[0..2]}-#{primary_phone[3..5]}-#{primary_phone[6..9]}"
+  end
+
+  def other_phone_display
+    return nil unless other_phone.present?
+    "#{other_phone[0..2]}-#{other_phone[3..5]}-#{other_phone[6..9]}"
+  end  
+end

--- a/app/models/concerns/attribute_displayable.rb
+++ b/app/models/concerns/attribute_displayable.rb
@@ -1,3 +1,4 @@
+# Methods related to displaying attributes on the patient model
 module AttributeDisplayable
   extend ActiveSupport::Concern
 
@@ -9,5 +10,5 @@ module AttributeDisplayable
   def other_phone_display
     return nil unless other_phone.present?
     "#{other_phone[0..2]}-#{other_phone[3..5]}-#{other_phone[6..9]}"
-  end  
+  end
 end

--- a/app/models/concerns/callable.rb
+++ b/app/models/concerns/callable.rb
@@ -1,3 +1,4 @@
+# Methods relating to calls or contacts
 module Callable
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/callable.rb
+++ b/app/models/concerns/callable.rb
@@ -1,0 +1,29 @@
+module Callable
+  extend ActiveSupport::Concern
+
+  def recent_calls
+    calls.includes(:created_by).order('created_at DESC').limit(10)
+  end
+
+  def old_calls
+    calls.includes(:created_by).order('created_at DESC').offset(10)
+  end
+
+  class_methods do
+    def contacted_since(datetime)
+      patients_reached = []
+      all.each do |patient|
+        calls = patient.calls.select { |call| call.status == 'Reached patient' &&
+                                              call.created_at >= datetime }
+        patients_reached << patient if calls.present?
+      end
+
+      # Should we use this or first call?
+      first_contact = patients_reached.select { |patient| patient.initial_call_date >= datetime }
+
+      # hard coding in first_contacts and pledges_sent for now
+      { since: datetime, contacts: patients_reached.length,
+        first_contacts: first_contact.length, pledges_sent: 20 }
+    end
+  end
+end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -1,0 +1,8 @@
+# Methods pertaining to parsing history_tracks
+module HistoryTrackable
+  extend ActiveSupport::Concern
+
+  def recent_history_tracks
+    history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+  end
+end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -2,6 +2,15 @@
 module HistoryTrackable
   extend ActiveSupport::Concern
 
+  included do
+    include Mongoid::History::Trackable
+    track_history on: self.fields.keys + [:updated_by_id],
+                  version_field: :version,
+                  track_create: true,
+                  track_update: true,
+                  track_destroy: true
+  end
+
   def recent_history_tracks
     history_tracks.select { |ht| ht.updated_at > 6.days.ago }
   end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -2,13 +2,9 @@
 module HistoryTrackable
   extend ActiveSupport::Concern
 
-  included do
-    include Mongoid::History::Trackable
-    track_history on: self.fields.keys + [:updated_by_id],
-                  version_field: :version,
-                  track_create: true,
-                  track_update: true,
-                  track_destroy: true
+  def assemble_audit_trails
+    (history_tracks | pregnancy.history_tracks).sort_by(&:created_at)
+                                               .reverse
   end
 
   def recent_history_tracks

--- a/app/models/concerns/notetakeable.rb
+++ b/app/models/concerns/notetakeable.rb
@@ -1,3 +1,4 @@
+# Methods relating to notes or parsing notes
 module Notetakeable
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/notetakeable.rb
+++ b/app/models/concerns/notetakeable.rb
@@ -1,0 +1,14 @@
+module Notetakeable
+  extend ActiveSupport::Concern
+
+  def most_recent_note_display_text
+    note_text = most_recent_note.try(:full_text).to_s
+    display_note = note_text[0..30]
+    display_note << '...' if note_text.length > 31
+    display_note
+  end
+
+  def most_recent_note
+    notes.order('created_at DESC').limit(1).first
+  end
+end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,0 +1,67 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  SEARCH_LIMIT = 15
+
+  class_methods do
+    # Case insensitive and phone number format agnostic!
+    def search(name_or_phone_str, lines = LINES)
+      # lines should be an array of symbols
+      name_regexp = /#{Regexp.escape(name_or_phone_str)}/i
+      clean_phone = name_or_phone_str.gsub(/\D/, '')
+      phone_regexp = /#{Regexp.escape(clean_phone)}/
+      identifier_regexp = /#{Regexp.escape(name_or_phone_str)}/i
+
+      all_matching_names = find_name_matches name_regexp, lines
+      all_matching_phones = find_phone_matches phone_regexp, lines
+      all_matching_identifiers = find_identifier_matches(identifier_regexp)
+
+      sort_and_limit_patient_matches(all_matching_names, all_matching_phones, all_matching_identifiers)
+    end
+
+    private
+
+    def sort_and_limit_patient_matches(*matches)
+      all_matches = matches.reduce do |results, matches_of_type|
+        results | matches_of_type
+      end
+
+      all_matches.sort { |a, b|
+        b.updated_at <=> a.updated_at
+      }.first(SEARCH_LIMIT)
+    end
+
+    def find_name_matches(name_regexp, lines = LINES)
+      if nonempty_regexp? name_regexp
+        primary_names = Patient.in(_line: lines).where name: name_regexp
+        other_names = Patient.in(_line: lines).where other_contact: name_regexp
+        return (primary_names | other_names)
+      end
+      []
+    end
+
+    def find_identifier_matches(identifier_regexp)
+      if nonempty_regexp? identifier_regexp
+        identifier = Patient.where identifier: identifier_regexp
+        return identifier
+      end
+      []
+    end
+
+    def find_phone_matches(phone_regexp, lines = LINES)
+      if nonempty_regexp? phone_regexp
+        primary_phones = Patient.in(_line: lines).where(primary_phone: phone_regexp)
+        other_phones = Patient.in(_line: lines).where(other_phone: phone_regexp)
+        return (primary_phones | other_phones)
+      end
+      []
+    end
+
+    def nonempty_regexp?(regexp)
+      # Escaped regexes are always present, so check presence
+      # after stripping out standard stuff
+      # (opening stuff to semicolon, closing parenthesis)
+      regexp.to_s.gsub(/^.*:/, '').chop.present?
+    end
+  end
+end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,3 +1,4 @@
+# Methods pertaining to patient search
 module Searchable
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/urgency.rb
+++ b/app/models/concerns/urgency.rb
@@ -1,3 +1,4 @@
+# Methods pertaining to urgent patients
 module Urgency
   extend ActiveSupport::Concern
 
@@ -26,10 +27,9 @@ module Urgency
     end
   end
 
-  private
+  # private
 
-  def recent_history_tracks
-    history_tracks.select { |ht| ht.updated_at > 6.days.ago }
-  end
-
+  # def recent_history_tracks
+  #   history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+  # end
 end

--- a/app/models/concerns/urgency.rb
+++ b/app/models/concerns/urgency.rb
@@ -25,4 +25,11 @@ module Urgency
       end
     end
   end
+
+  private
+
+  def recent_history_tracks
+    history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+  end
+
 end

--- a/app/models/concerns/urgency.rb
+++ b/app/models/concerns/urgency.rb
@@ -1,0 +1,28 @@
+module Urgency
+  extend ActiveSupport::Concern
+
+  def still_urgent?
+    # Verify that a pregnancy has not been marked urgent in the past six days
+    return false if recent_history_tracks.count == 0
+    return false if pregnancy.pledge_sent || pregnancy.resolved_without_dcaf
+    recent_history_tracks.sort.reverse.each do |history|
+      return true if history.marked_urgent?
+    end
+    false
+  end
+
+  class_methods do
+    def urgent_patients(lines = LINES)
+      Patient.in(_line: lines).where(urgent_flag: true)
+    end
+
+    def trim_urgent_patients
+      Patient.all do |patient|
+        unless patient.still_urgent?
+          patient.urgent_flag = false
+          patient.save
+        end
+      end
+    end
+  end
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -4,6 +4,7 @@ class Patient
   include Mongoid::Timestamps
   include Mongoid::Enum
   include Mongoid::Userstamp
+  include Mongoid::History::Trackable
   include StatusHelper
 
   # The following are concerns, or groupings of domain-related methods
@@ -97,6 +98,11 @@ class Patient
   # some validation of only one active pregnancy at a time
 
   # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
   mongoid_userstamp user_model: 'User'
 
   # Methods
@@ -117,11 +123,6 @@ class Patient
 
   def save_identifier
     self.identifier = "#{line[0]}#{primary_phone[-5]}-#{primary_phone[-4..-1]}"
-  end
-
-  def assemble_audit_trails
-    (history_tracks | pregnancy.history_tracks).sort_by(&:created_at)
-                                               .reverse
   end
 
   private

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,5 +1,4 @@
 # Object representing core patient information and demographic data.
-# require_relative 'concerns/auditable'
 
 class Patient
   include Mongoid::Document
@@ -12,6 +11,7 @@ class Patient
   include Callable
   include Notetakeable
   include Searchable
+  include AttributeDisplayable
 
   LINES.each do |line|
     scope line.downcase.to_sym, -> { where(:_line.in => [line]) }

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,4 +1,6 @@
 # Object representing core patient information and demographic data.
+# require_relative 'concerns/auditable'
+
 class Patient
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -6,6 +8,7 @@ class Patient
   include Mongoid::History::Trackable
   include Mongoid::Userstamp
   include StatusHelper
+  include Urgency
 
   SEARCH_LIMIT = 15
   LINES.each do |line|
@@ -98,18 +101,18 @@ class Patient
   mongoid_userstamp user_model: 'User'
 
   # Methods
-  def self.urgent_patients(lines = LINES)
-    Patient.in(_line: lines).where(urgent_flag: true)
-  end
+  # def self.urgent_patients(lines = LINES)
+  #   Patient.in(_line: lines).where(urgent_flag: true)
+  # end
 
-  def self.trim_urgent_patients
-    Patient.all do |patient|
-      unless patient.still_urgent?
-        patient.urgent_flag = false
-        patient.save
-      end
-    end
-  end
+  # def self.trim_urgent_patients
+  #   Patient.all do |patient|
+  #     unless patient.still_urgent?
+  #       patient.urgent_flag = false
+  #       patient.save
+  #     end
+  #   end
+  # end
 
   def self.pledged_status_summary(num_days = 7)
     # return pledge totals for patients with appts in the next num_days
@@ -186,15 +189,15 @@ class Patient
     self.identifier = "#{line[0]}#{primary_phone[-5]}-#{primary_phone[-4..-1]}"
   end
 
-  def still_urgent?
-    # Verify that a pregnancy has not been marked urgent in the past six days
-    return false if recent_history_tracks.count == 0
-    return false if pregnancy.pledge_sent || pregnancy.resolved_without_dcaf
-    recent_history_tracks.sort.reverse.each do |history|
-      return true if history.marked_urgent?
-    end
-    false
-  end
+  # def still_urgent?
+  #   # Verify that a pregnancy has not been marked urgent in the past six days
+  #   return false if recent_history_tracks.count == 0
+  #   return false if pregnancy.pledge_sent || pregnancy.resolved_without_dcaf
+  #   recent_history_tracks.sort.reverse.each do |history|
+  #     return true if history.marked_urgent?
+  #   end
+  #   false
+  # end
 
   def assemble_audit_trails
     (history_tracks | pregnancy.history_tracks).sort_by(&:created_at)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,7 +3,6 @@ class Patient
   include Mongoid::Document
   include Mongoid::Timestamps
   include Mongoid::Enum
-  include Mongoid::History::Trackable
   include Mongoid::Userstamp
   include StatusHelper
 
@@ -98,11 +97,6 @@ class Patient
   # some validation of only one active pregnancy at a time
 
   # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
   mongoid_userstamp user_model: 'User'
 
   # Methods

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -9,6 +9,9 @@ class Patient
   include Mongoid::Userstamp
   include StatusHelper
   include Urgency
+  include Callable
+  include Notetakeable
+  include Searchable
 
   SEARCH_LIMIT = 15
   LINES.each do |line|
@@ -101,19 +104,6 @@ class Patient
   mongoid_userstamp user_model: 'User'
 
   # Methods
-  # def self.urgent_patients(lines = LINES)
-  #   Patient.in(_line: lines).where(urgent_flag: true)
-  # end
-
-  # def self.trim_urgent_patients
-  #   Patient.all do |patient|
-  #     unless patient.still_urgent?
-  #       patient.urgent_flag = false
-  #       patient.save
-  #     end
-  #   end
-  # end
-
   def self.pledged_status_summary(num_days = 7)
     # return pledge totals for patients with appts in the next num_days
     # TODO move to Pledge class, when implemented?
@@ -129,51 +119,16 @@ class Patient
     { pledged: outstanding_pledges, sent: sent_total }
   end
 
-  def self.contacted_since(datetime)
-    patients_reached = []
-    all.each do |patient|
-      calls = patient.calls.select { |call| call.status == 'Reached patient' &&
-                                            call.created_at >= datetime }
-      patients_reached << patient if calls.present?
-    end
-
-    # Should we use this or first call?
-    first_contact = patients_reached.select { |patient| patient.initial_call_date >= datetime }
-
-    # hard coding in first_contacts and pledges_sent for now
-    { since: datetime, contacts: patients_reached.length,
-      first_contacts: first_contact.length, pledges_sent: 20 }
-  end
-
-  def recent_calls
-    calls.includes(:created_by).order('created_at DESC').limit(10)
-  end
-
-  def old_calls
-    calls.includes(:created_by).order('created_at DESC').offset(10)
-  end
-
-  def most_recent_note_display_text
-    note_text = most_recent_note.try(:full_text).to_s
-    display_note = note_text[0..30]
-    display_note << '...' if note_text.length > 31
-    display_note
-  end
-
-  def most_recent_note
-    notes.order('created_at DESC').limit(1).first
+  # TODO: reimplement once pledge is available
+  def most_recent_pledge_display_date
+   display_date = most_recent_pledge.try(:sent).to_s
+   display_date
   end
 
   # TODO: reimplement once pledge is available
-  #def most_recent_pledge_display_date
-  #  display_date = most_recent_pledge.try(:sent).to_s
-  #  display_date
-  #end
-
-  # TODO: reimplement once pledge is available
-  #def most_recent_pledge
-  #  pledges.order('created_at DESC').limit(1).first
-  #end
+  def most_recent_pledge
+   pledges.order('created_at DESC').limit(1).first
+  end
 
   def primary_phone_display
     return nil unless primary_phone.present?
@@ -189,89 +144,18 @@ class Patient
     self.identifier = "#{line[0]}#{primary_phone[-5]}-#{primary_phone[-4..-1]}"
   end
 
-  # def still_urgent?
-  #   # Verify that a pregnancy has not been marked urgent in the past six days
-  #   return false if recent_history_tracks.count == 0
-  #   return false if pregnancy.pledge_sent || pregnancy.resolved_without_dcaf
-  #   recent_history_tracks.sort.reverse.each do |history|
-  #     return true if history.marked_urgent?
-  #   end
-  #   false
-  # end
-
   def assemble_audit_trails
     (history_tracks | pregnancy.history_tracks).sort_by(&:created_at)
                                                .reverse
   end
 
   # Search-related stuff
-  class << self
-    # Case insensitive and phone number format agnostic!
-    def search(name_or_phone_str, lines = LINES)
-      # lines should be an array of symbols
-      name_regexp = /#{Regexp.escape(name_or_phone_str)}/i
-      clean_phone = name_or_phone_str.gsub(/\D/, '')
-      phone_regexp = /#{Regexp.escape(clean_phone)}/
-      identifier_regexp = /#{Regexp.escape(name_or_phone_str)}/i
-
-      all_matching_names = find_name_matches name_regexp, lines
-      all_matching_phones = find_phone_matches phone_regexp, lines
-      all_matching_identifiers = find_identifier_matches(identifier_regexp)
-
-      sort_and_limit_patient_matches(all_matching_names, all_matching_phones, all_matching_identifiers)
-    end
-
-    private
-
-
-    def sort_and_limit_patient_matches(*matches)
-      all_matches = matches.reduce{ |results, matches_of_type|
-        results | matches_of_type
-      }
-      all_matches.sort { |a,b|
-        b.updated_at <=> a.updated_at
-      }.first(SEARCH_LIMIT)
-    end
-
-    def find_name_matches(name_regexp, lines = LINES)
-      if nonempty_regexp? name_regexp
-        primary_names = Patient.in(_line: lines).where name: name_regexp
-        other_names = Patient.in(_line: lines).where other_contact: name_regexp
-        return (primary_names | other_names)
-      end
-      []
-    end
-
-    def find_identifier_matches(identifier_regexp)
-      if nonempty_regexp? identifier_regexp
-        identifier = Patient.where identifier: identifier_regexp
-        return identifier
-      end
-      []
-    end
-
-    def find_phone_matches(phone_regexp, lines = LINES)
-      if nonempty_regexp? phone_regexp
-        primary_phones = Patient.in(_line: lines).where(primary_phone: phone_regexp)
-        other_phones = Patient.in(_line: lines).where(other_phone: phone_regexp)
-        return (primary_phones | other_phones)
-      end
-      []
-    end
-
-    def nonempty_regexp?(regexp)
-      # Escaped regexes are always present, so check presence
-      # after stripping out standard stuff
-      # (opening stuff to semicolon, closing parenthesis)
-      regexp.to_s.gsub(/^.*:/, '').chop.present?
-    end
-  end
 
   private
 
-  def recent_history_tracks
-    history_tracks.select { |ht| ht.updated_at > 6.days.ago }
-  end
+  # def recent_history_tracks
+  #   history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+  # end
 
   def confirm_appointment_after_initial_call
     if appointment_date.present? && initial_call_date > appointment_date

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,5 +1,4 @@
 # Object representing core patient information and demographic data.
-
 class Patient
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -7,11 +6,15 @@ class Patient
   include Mongoid::History::Trackable
   include Mongoid::Userstamp
   include StatusHelper
+
+  # The following are concerns, or groupings of domain-related methods
+  # This blog post is a good intro: https://vaidehijoshi.github.io/blog/2015/10/13/stop-worrying-and-start-being-concerned-activesupport-concerns/
   include Urgency
   include Callable
   include Notetakeable
   include Searchable
   include AttributeDisplayable
+  include HistoryTrackable
 
   LINES.each do |line|
     scope line.downcase.to_sym, -> { where(:_line.in => [line]) }
@@ -116,27 +119,6 @@ class Patient
       end
     end
     { pledged: outstanding_pledges, sent: sent_total }
-  end
-
-  # TODO: reimplement once pledge is available
-  def most_recent_pledge_display_date
-   display_date = most_recent_pledge.try(:sent).to_s
-   display_date
-  end
-
-  # TODO: reimplement once pledge is available
-  def most_recent_pledge
-   pledges.order('created_at DESC').limit(1).first
-  end
-
-  def primary_phone_display
-    return nil unless primary_phone.present?
-    "#{primary_phone[0..2]}-#{primary_phone[3..5]}-#{primary_phone[6..9]}"
-  end
-
-  def other_phone_display
-    return nil unless other_phone.present?
-    "#{other_phone[0..2]}-#{other_phone[3..5]}-#{other_phone[6..9]}"
   end
 
   def save_identifier

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -13,7 +13,6 @@ class Patient
   include Notetakeable
   include Searchable
 
-  SEARCH_LIMIT = 15
   LINES.each do |line|
     scope line.downcase.to_sym, -> { where(:_line.in => [line]) }
   end
@@ -149,13 +148,7 @@ class Patient
                                                .reverse
   end
 
-  # Search-related stuff
-
   private
-
-  # def recent_history_tracks
-  #   history_tracks.select { |ht| ht.updated_at > 6.days.ago }
-  # end
 
   def confirm_appointment_after_initial_call
     if appointment_date.present? && initial_call_date > appointment_date


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

The patient object was getting a little massive. 300 line models is no way to live.

This begins the process in #948 by moving relevant sets of methods into their own concerns.

This pull request makes the following changes:
* Breaks patient object into a core, plus Urgency, Callable, Notetakeable, Searchable, and AttributeDisplayable concerns

@lomky seeking your thoughts on the patterns here -- does dividing things up this way and the names I picked make sense to you? Anything else I should extract?